### PR TITLE
feat: adds fixtures to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ This repository holds hundreds of code examples for using the EasyPost API acros
 
 - `official` holds all the official code snippets that populate on the EasyPost website
   - `docs` holds all the code snippets that populate on our API docs page. Each language will have its own subdirectory
+  - `fixtures` holds all of the test data used as fixtures in our client library test suites
   - `guides` holds all the code snippets that populate on our guides page. Each language will have its own subdirectory
 - `community` holds code snippets contributed from the community. These may include custom workflows, how to integrate EasyPost with other software, etc

--- a/official/fixtures/client-library-fixtures.json
+++ b/official/fixtures/client-library-fixtures.json
@@ -1,12 +1,22 @@
 {
   "addresses": {
-    "from_address": {
+    "ca_address_1": {
       "name": "Jack Sparrow",
       "street1": "388 Townsend St",
       "street2": "Apt 20",
       "city": "San Francisco",
       "state": "CA",
       "zip": "94107",
+      "country": "US",
+      "email": "test@example.com",
+      "phone": "5555555555"
+    },
+    "ca_address_2": {
+      "name": "Elizabeth Swan",
+      "street1": "179 N Harbor Dr",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "zip": "90277",
       "country": "US",
       "email": "test@example.com",
       "phone": "5555555555"
@@ -18,16 +28,6 @@
       "city": "San Francisco",
       "state": "CA",
       "zip": "94104",
-      "country": "US",
-      "email": "test@example.com",
-      "phone": "5555555555"
-    },
-    "to_address": {
-      "name": "Elizabeth Swan",
-      "street1": "179 N Harbor Dr",
-      "city": "Redondo Beach",
-      "state": "CA",
-      "zip": "90277",
       "country": "US",
       "email": "test@example.com",
       "phone": "5555555555"
@@ -140,7 +140,7 @@
   "insurances": {
     "basic": {
       "from_address": {
-        "company": "EasyPost",
+        "name": "Jack Sparrow",
         "street1": "388 Townsend St",
         "street2": "Apt 20",
         "city": "San Francisco",
@@ -151,7 +151,7 @@
         "phone": "5555555555"
       },
       "to_address": {
-        "name": "Jack Sparrow",
+        "name": "Elizabeth Swan",
         "street1": "179 N Harbor Dr",
         "city": "Redondo Beach",
         "state": "CA",
@@ -167,7 +167,7 @@
   "orders": {
     "basic": {
       "from_address": {
-        "company": "EasyPost",
+        "name": "Jack Sparrow",
         "street1": "388 Townsend St",
         "street2": "Apt 20",
         "city": "San Francisco",
@@ -178,7 +178,7 @@
         "phone": "5555555555"
       },
       "to_address": {
-        "name": "Jack Sparrow",
+        "name": "Elizabeth Swan",
         "street1": "179 N Harbor Dr",
         "city": "Redondo Beach",
         "state": "CA",
@@ -190,7 +190,7 @@
       "shipments": [
         {
           "from_address": {
-            "company": "EasyPost",
+            "name": "Jack Sparrow",
             "street1": "388 Townsend St",
             "street2": "Apt 20",
             "city": "San Francisco",
@@ -201,7 +201,7 @@
             "phone": "5555555555"
           },
           "to_address": {
-            "name": "Jack Sparrow",
+            "name": "Elizabeth Swan",
             "street1": "179 N Harbor Dr",
             "city": "Redondo Beach",
             "state": "CA",
@@ -240,10 +240,11 @@
     "basic": {
       "address": {
         "name": "Jack Sparrow",
-        "street1": "179 N Harbor Dr",
-        "city": "Redondo Beach",
+        "street1": "388 Townsend St",
+        "street2": "Apt 20",
+        "city": "San Francisco",
         "state": "CA",
-        "zip": "90277",
+        "zip": "94107",
         "country": "US",
         "email": "test@example.com",
         "phone": "5555555555"
@@ -265,7 +266,7 @@
   "shipments": {
     "basic_domestic": {
       "from_address": {
-        "company": "EasyPost",
+        "name": "Jack Sparrow",
         "street1": "388 Townsend St",
         "street2": "Apt 20",
         "city": "San Francisco",
@@ -276,7 +277,7 @@
         "phone": "5555555555"
       },
       "to_address": {
-        "name": "Jack Sparrow",
+        "name": "Elizabeth Swan",
         "street1": "179 N Harbor Dr",
         "city": "Redondo Beach",
         "state": "CA",
@@ -294,7 +295,7 @@
     },
     "full": {
       "from_address": {
-        "company": "EasyPost",
+        "name": "Jack Sparrow",
         "street1": "388 Townsend St",
         "street2": "Apt 20",
         "city": "San Francisco",
@@ -305,7 +306,7 @@
         "phone": "5555555555"
       },
       "to_address": {
-        "name": "Jack Sparrow",
+        "name": "Elizabeth Swan",
         "street1": "179 N Harbor Dr",
         "city": "Redondo Beach",
         "state": "CA",

--- a/official/fixtures/client-library-fixtures.json
+++ b/official/fixtures/client-library-fixtures.json
@@ -1,0 +1,358 @@
+{
+  "addresses": {
+    "from_address": {
+      "name": "Jack Sparrow",
+      "street1": "388 Townsend St",
+      "street2": "Apt 20",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94107",
+      "country": "US",
+      "email": "test@example.com",
+      "phone": "5555555555"
+    },
+    "incorrect": {
+      "company": "EasyPost",
+      "street1": "417 montgomery street",
+      "street2": "FL 5",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94104",
+      "country": "US",
+      "email": "test@example.com",
+      "phone": "5555555555"
+    },
+    "to_address": {
+      "name": "Elizabeth Swan",
+      "street1": "179 N Harbor Dr",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "zip": "90277",
+      "country": "US",
+      "email": "test@example.com",
+      "phone": "5555555555"
+    }
+  },
+  "carrier_accounts": {
+    "basic": {
+      "type": "DhlEcsAccount",
+      "credentials": {
+        "client_id": "123456",
+        "client_secret": "123abc",
+        "distribution_center": "USLAX1",
+        "pickup_id": "123456"
+      },
+      "test_credentials": {
+        "client_id": "123456",
+        "client_secret": "123abc",
+        "distribution_center": "USLAX1",
+        "pickup_id": "123456"
+      }
+    }
+  },
+  "carrier_strings": {
+    "usps": "USPS"
+  },
+  "credit_cards": {
+    "test": {
+      "number": "4536410136126170",
+      "expirationMonth": "05",
+      "expirationYear": "2028",
+      "cvc": "778"
+    }
+  },
+  "customs_infos": {
+    "basic": {
+      "eel_pfc": "NOEEI 30.37(a)",
+      "customs_certify": true,
+      "customs_signer": "Steve Brule",
+      "contents_type": "merchandise",
+      "contents_explanation": "",
+      "restriction_type": "none",
+      "non_delivery_option": "return",
+      "customs_items": [
+        {
+          "description": "Sweet shirts",
+          "quantity": 2,
+          "weight": 11,
+          "value": 23.25,
+          "hs_tariff_number": "654321",
+          "origin_country": "US"
+        }
+      ]
+    }
+  },
+  "customs_items": {
+    "basic": {
+      "description": "Sweet shirts",
+      "quantity": 2,
+      "weight": 11,
+      "value": 23.25,
+      "hs_tariff_number": "654321",
+      "origin_country": "US"
+    }
+  },
+  "event_body": {
+    "result": {
+      "id": "batch_123...",
+      "object": "Batch",
+      "mode": "test",
+      "state": "created",
+      "num_shipments": 0,
+      "reference": null,
+      "created_at": "2022-07-26T17:22:32Z",
+      "updated_at": "2022-07-26T17:22:32Z",
+      "scan_form": null,
+      "shipments": [],
+      "status": {
+        "created": 0,
+        "queued_for_purchase": 0,
+        "creation_failed": 0,
+        "postage_purchased": 0,
+        "postage_purchase_failed": 0
+      },
+      "pickup": null,
+      "label_url": null
+    },
+    "description": "batch.created",
+    "mode": "test",
+    "previous_attributes": null,
+    "completed_urls": null,
+    "user_id": "user_123...",
+    "status": "pending",
+    "object": "Event",
+    "id": "evt_123..."
+  },
+  "form_options": {
+    "rma": {
+      "barcode": "RMA12345678900",
+      "line_items": [
+        {
+          "product": {
+            "title": "Square Reader",
+            "barcode": "855658003251"
+          },
+          "units": 8
+        }
+      ]
+    }
+  },
+  "insurances": {
+    "basic": {
+      "from_address": {
+        "company": "EasyPost",
+        "street1": "388 Townsend St",
+        "street2": "Apt 20",
+        "city": "San Francisco",
+        "state": "CA",
+        "zip": "94107",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "to_address": {
+        "name": "Jack Sparrow",
+        "street1": "179 N Harbor Dr",
+        "city": "Redondo Beach",
+        "state": "CA",
+        "zip": "90277",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "carrier": "USPS",
+      "amount": "100"
+    }
+  },
+  "orders": {
+    "basic": {
+      "from_address": {
+        "company": "EasyPost",
+        "street1": "388 Townsend St",
+        "street2": "Apt 20",
+        "city": "San Francisco",
+        "state": "CA",
+        "zip": "94107",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "to_address": {
+        "name": "Jack Sparrow",
+        "street1": "179 N Harbor Dr",
+        "city": "Redondo Beach",
+        "state": "CA",
+        "zip": "90277",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "shipments": [
+        {
+          "from_address": {
+            "company": "EasyPost",
+            "street1": "388 Townsend St",
+            "street2": "Apt 20",
+            "city": "San Francisco",
+            "state": "CA",
+            "zip": "94107",
+            "country": "US",
+            "email": "test@example.com",
+            "phone": "5555555555"
+          },
+          "to_address": {
+            "name": "Jack Sparrow",
+            "street1": "179 N Harbor Dr",
+            "city": "Redondo Beach",
+            "state": "CA",
+            "zip": "90277",
+            "country": "US",
+            "email": "test@example.com",
+            "phone": "5555555555"
+          },
+          "parcel": {
+            "length": 10,
+            "width": 8,
+            "height": 4,
+            "weight": 15.4
+          }
+        }
+      ]
+    }
+  },
+  "page_sizes": {
+    "one_result": 1,
+    "five_results": 5,
+    "ten_results": 10,
+    "twenty_results": 20,
+    "fifty_results": 50,
+    "one_hundred_results": 100
+  },
+  "parcels": {
+    "basic": {
+      "length": 10,
+      "width": 8,
+      "height": 4,
+      "weight": 15.4
+    }
+  },
+  "pickups": {
+    "basic": {
+      "address": {
+        "name": "Jack Sparrow",
+        "street1": "179 N Harbor Dr",
+        "city": "Redondo Beach",
+        "state": "CA",
+        "zip": "90277",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "min_datetime": "2022-08-01",
+      "max_datetime": "2022-08-02",
+      "instructions": "Pickup at front door"
+    }
+  },
+  "report_types": {
+    "shipment": "shipment"
+  },
+  "service_names": {
+    "usps": {
+      "first_service": "First",
+      "pickup_service": "NextDay"
+    }
+  },
+  "shipments": {
+    "basic_domestic": {
+      "from_address": {
+        "company": "EasyPost",
+        "street1": "388 Townsend St",
+        "street2": "Apt 20",
+        "city": "San Francisco",
+        "state": "CA",
+        "zip": "94107",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "to_address": {
+        "name": "Jack Sparrow",
+        "street1": "179 N Harbor Dr",
+        "city": "Redondo Beach",
+        "state": "CA",
+        "zip": "90277",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "parcel": {
+        "length": 10,
+        "width": 8,
+        "height": 4,
+        "weight": 15.4
+      }
+    },
+    "full": {
+      "from_address": {
+        "company": "EasyPost",
+        "street1": "388 Townsend St",
+        "street2": "Apt 20",
+        "city": "San Francisco",
+        "state": "CA",
+        "zip": "94107",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "to_address": {
+        "name": "Jack Sparrow",
+        "street1": "179 N Harbor Dr",
+        "city": "Redondo Beach",
+        "state": "CA",
+        "zip": "90277",
+        "country": "US",
+        "email": "test@example.com",
+        "phone": "5555555555"
+      },
+      "parcel": {
+        "length": 10,
+        "width": 8,
+        "height": 4,
+        "weight": 15.4
+      },
+      "customs_info": {
+        "eel_pfc": "NOEEI 30.37(a)",
+        "customs_certify": true,
+        "customs_signer": "Steve Brule",
+        "contents_type": "merchandise",
+        "contents_explanation": "",
+        "restriction_type": "none",
+        "non_delivery_option": "return",
+        "customs_items": [
+          {
+            "description": "Sweet shirts",
+            "quantity": 2,
+            "weight": 11,
+            "value": 23.25,
+            "hs_tariff_number": "654321",
+            "origin_country": "US"
+          }
+        ]
+      },
+      "options": {
+        "label_format": "PNG",
+        "invoice_number": "123"
+      },
+      "reference": "123"
+    }
+  },
+  "tax_identifiers": {
+    "basic": {
+      "entity": "SENDER",
+      "tax_id_type": "IOSS",
+      "tax_id": "12345",
+      "issuing_country": "GB"
+    }
+  },
+  "webhook_url": "http://example.com"
+}


### PR DESCRIPTION
Adds a reusable JSON blob of fixture data we'll start using in our client libraries. Each library will submodule this new `examples` repo to get examples to live alongside the code as well as allowing us to reuse test data with a single source of truth.