### PR TITLE
fix: fully qualify pickup min/max datetimes

### DIFF
--- a/official/fixtures/client-library-fixtures.json
+++ b/official/fixtures/client-library-fixtures.json
@@ -218,8 +218,8 @@
         "email": "test@example.com",
         "phone": "5555555555"
       },
-      "min_datetime": "2022-08-01",
-      "max_datetime": "2022-08-02",
+      "min_datetime": "2022-08-01T00:00:00.00Z",
+      "max_datetime": "2022-08-02T00:00:00.00Z",
       "instructions": "Pickup at front door"
     }
   },


### PR DESCRIPTION
Languages like Golang can't deserialize the min/max datetime of a Pickup unless it is fully qualified. We fix this here.
