### PR TITLE
Fix shipments/:id/label cURL request

### DIFF
--- a/official/docs/curl/current/shipments/label.sh
+++ b/official/docs/curl/current/shipments/label.sh
@@ -1,4 +1,4 @@
-curl -X POST https://api.easypost.com/v2/shipments/shp_.../label \
+curl -X GET https://api.easypost.com/v2/shipments/shp_.../label \
   -u "$EASYPOST_API_KEY": \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
The `shipments/:id/label` endpoint is actually a GET.

A POST gives us:

```
{
    "error": {
        "code": "NOT_FOUND",
        "message": "The requested resource could not be found.",
        "errors": []
    }
}
```

A GET gives a successful 200.

See https://github.com/EasyPost/easypost-python/blob/master/easypost/shipment.py#L84 for how our Python client library does a GET not a POST.