### PR TITLE
chore: update test credit card fixture

### DIFF
--- a/official/fixtures/client-library-fixtures.json
+++ b/official/fixtures/client-library-fixtures.json
@@ -55,10 +55,10 @@
   },
   "credit_cards": {
     "test": {
-      "number": "4536410136126170",
-      "expiration_month": "05",
-      "expiration_year": "2028",
-      "cvc": "778"
+      "number": "4242424242424242",
+      "expiration_month": "12",
+      "expiration_year": "2030",
+      "cvc": "123"
     }
   },
   "customs_infos": {


### PR DESCRIPTION
Updates the test credit card to a new test number provided by Stripe.