### PR TITLE
Revert "chore: update test credit card fixture"

### DIFF
--- a/official/fixtures/client-library-fixtures.json
+++ b/official/fixtures/client-library-fixtures.json
@@ -55,10 +55,10 @@
   },
   "credit_cards": {
     "test": {
-      "number": "4242424242424242",
-      "expiration_month": "12",
-      "expiration_year": "2030",
-      "cvc": "123"
+      "number": "4536410136126170",
+      "expiration_month": "05",
+      "expiration_year": "2028",
+      "cvc": "778"
     }
   },
   "customs_infos": {


### PR DESCRIPTION
Apparently we went down this road before and this doesn't work, even though I definitely had it work this morning, Stripe's API is complaining we are sending test credit card details to their prod endpoint which is valid since we don't hit the test one. We're trying to test in production which isn't super possible except by using our fake prod card as we were before.

This reverts commit 873ab73e2b0890c498dba3ecf0eb591c5b398dea.
