### PR TITLE
fix: easypost url for sms guide

### DIFF
--- a/official/guides/sms-tracking-tutorial/step3a.sh
+++ b/official/guides/sms-tracking-tutorial/step3a.sh
@@ -1,1 +1,1 @@
-curl -X POST easypost.com/api/v2/webhooks -u "$EASYPOST_API_KEY": -d 'webhook[url]=http://xxxxxxxx.ngrok.io/easypost-webhook&webhook[mode]=test'
+curl -X POST https://api.easypost.com/v2/webhooks -u "$EASYPOST_API_KEY": -d 'webhook[url]=http://xxxxxxxx.ngrok.io/easypost-webhook&webhook[mode]=test'


### PR DESCRIPTION
During our convos of versioning, we discussed what the canonical URL for our endpoint is. Searched for any incorrect references and only found one for what we are responsible for (this is still valid but will be turned off in the future, fixing now).
