### PR TITLE
feat: add v6 set of PHP docs

### DIFF
--- a/official/docs/php/current/addresses/create-and-verify.php
+++ b/official/docs/php/current/addresses/create-and-verify.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$address = \EasyPost\Address::create_and_verify([
+$address = $client->address->createAndVerify([
     'street1' => '417 Montgomery Street',
     'street2' => 'FL 5',
     'city'    => 'San Francisco',

--- a/official/docs/php/current/addresses/create.php
+++ b/official/docs/php/current/addresses/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$address = \EasyPost\Address::create([
+$address = $client->address->create([
     'street1' => '417 MONTGOMERY ST',
     'street2' => 'FLOOR 5',
     'city'    => 'San Francisco',

--- a/official/docs/php/current/addresses/list.php
+++ b/official/docs/php/current/addresses/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$addresses = \EasyPost\Address::all([
+$addresses = $client->address->all([
     'page_size' => 5
 ]);
 

--- a/official/docs/php/current/addresses/retrieve.php
+++ b/official/docs/php/current/addresses/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$address = \EasyPost\Address::retrieve('adr_...');
+$address = $client->address->retrieve('adr_...');
 
 echo $address;

--- a/official/docs/php/current/addresses/verify-failure.php
+++ b/official/docs/php/current/addresses/verify-failure.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$address = \EasyPost\Address::create([
+$address = $client->address->create([
     'street1' => 'UNDELIVERABLE ST',
     'city'    => 'San Francisco',
     'state'   => 'CA',

--- a/official/docs/php/current/addresses/verify-param.php
+++ b/official/docs/php/current/addresses/verify-param.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$address = \EasyPost\Address::create([
+$address = $client->address->create([
     'verify'  => true,
     'street1' => '417 Montgomery Streat',
     'street2' => '5',

--- a/official/docs/php/current/addresses/verify-strict-param.php
+++ b/official/docs/php/current/addresses/verify-strict-param.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$address = \EasyPost\Address::create([
+$address = $client->address->create([
     'verify_strict'  => true,
     'street1'        => '417 MONTGOMERY ST',
     'street2'        => 'FL 5',

--- a/official/docs/php/current/addresses/verify.php
+++ b/official/docs/php/current/addresses/verify.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$address = \EasyPost\Address::create([
+$address = $client->address->create([
     'street1' => '417 montgomery streat',
     'street2' => 'FL 5',
     'city'    => 'San Francisco',
@@ -13,6 +13,6 @@ $address = \EasyPost\Address::create([
     'phone'   => '415-123-4567'
 ]);
 
-$address->verify();
+$verifiedAddress = $client->$address->verify($address->id);
 
-echo $address;
+echo $verifiedAddress;

--- a/official/docs/php/current/api-keys/retrieve.php
+++ b/official/docs/php/current/api-keys/retrieve.php
@@ -1,12 +1,12 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 // Retrieve all API keys (authenticated user and child user keys)
-$apiKeys = \EasyPost\User::all_api_keys();
+$apiKeys = $client->user->allApiKeys();
 
 // Retrieve API keys for a child user
-$childUser = \EasyPost\User::retrieve('user_...');
-$apiKeys = $childUser->api_keys();
+$childUser = $client->user->retrieve('user_...');
+$apiKeys = $client->$user->apiKeys($childUser->id);
 
 echo $apiKeys;

--- a/official/docs/php/current/batches/add-shipments.php
+++ b/official/docs/php/current/batches/add-shipments.php
@@ -1,14 +1,17 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$batch = \EasyPost\Batch::retrieve('batch_...');
+$batch = $client->batch->retrieve('batch_...');
 
-$batch->add_shipments([
-    'shipments' => [
-        ['id' => 'shp_...'],
-        ['id' => 'shp_...'],
+$batchWithShipments = $client->$batch->addShipments(
+    $batch->id,
+    [
+        'shipments' => [
+            ['id' => 'shp_...'],
+            ['id' => 'shp_...'],
+        ]
     ]
-]);
+);
 
-echo $batch;
+echo $batchWithShipments;

--- a/official/docs/php/current/batches/buy.php
+++ b/official/docs/php/current/batches/buy.php
@@ -1,9 +1,9 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$batch = \EasyPost\Batch::retrieve('batch_...');
+$batch = $client->batch->retrieve('batch_...');
 
-$batch->buy();
+$boughtBatch = $client->$batch->buy($batch->id);
 
-echo $batch;
+echo $boughtBatch;

--- a/official/docs/php/current/batches/create.php
+++ b/official/docs/php/current/batches/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$batch = \EasyPost\Batch::create([
+$batch = $client->batch->create([
     'shipments' => [
         ['id' => 'shp_...'],
         ['id' => 'shp_...'],

--- a/official/docs/php/current/batches/label.php
+++ b/official/docs/php/current/batches/label.php
@@ -1,9 +1,12 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$batch = \EasyPost\Batch::retrieve('batch_...');
+$batch = $client->batch->retrieve('batch_...');
 
-$batch->label(['file_format' => 'PDF']);
+$batchWithLabel = $client->$batch->label(
+    $batch->id,
+    ['file_format' => 'PDF']
+);
 
-echo $batch;
+echo $batchWithLabel;

--- a/official/docs/php/current/batches/list.php
+++ b/official/docs/php/current/batches/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$batches = \EasyPost\Batch::all([
+$batches = $client->batch->all([
     'page_size' => 5,
 ]);
 

--- a/official/docs/php/current/batches/remove-shipments.php
+++ b/official/docs/php/current/batches/remove-shipments.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $batch = $client->batch->retrieve('batch_...');
 
-$batchWithoutShipments = $batch->remove_shipments([
+$batchWithoutShipments = $batch->removeShipments([
     'shipments' => [
         ['id' => 'shp_...']
     ]

--- a/official/docs/php/current/batches/remove-shipments.php
+++ b/official/docs/php/current/batches/remove-shipments.php
@@ -1,13 +1,13 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$batch = \EasyPost\Batch::retrieve('batch_...');
+$batch = $client->batch->retrieve('batch_...');
 
-$batch->remove_shipments([
+$batchWithoutShipments = $batch->remove_shipments([
     'shipments' => [
         ['id' => 'shp_...']
     ]
 ]);
 
-echo $batch;
+echo $batchWithoutShipments;

--- a/official/docs/php/current/batches/remove-shipments.php
+++ b/official/docs/php/current/batches/remove-shipments.php
@@ -4,10 +4,13 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $batch = $client->batch->retrieve('batch_...');
 
-$batchWithoutShipments = $batch->removeShipments([
-    'shipments' => [
-        ['id' => 'shp_...']
+$batchWithoutShipments = $client->$batch->removeShipments(
+    $shipment->id,
+    [
+        'shipments' => [
+            ['id' => 'shp_...']
+        ]
     ]
-]);
+);
 
 echo $batchWithoutShipments;

--- a/official/docs/php/current/batches/retrieve.php
+++ b/official/docs/php/current/batches/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$batch = \EasyPost\Batch::retrieve('batch_...');
+$batch = $client->batch->retrieve('batch_...');
 
 echo $batch;

--- a/official/docs/php/current/batches/scan-forms.php
+++ b/official/docs/php/current/batches/scan-forms.php
@@ -1,9 +1,9 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$batch = \EasyPost\Batch::retrieve('batch_...');
+$batch = $client->batch->retrieve('batch_...');
 
-$batch->create_scan_form();
+$batchWithScanForm = $client->$batch->createScanForm($batch->id);
 
-echo $batch;
+echo $batchWithScanForm;

--- a/official/docs/php/current/billing/create-ep-credit-card.php
+++ b/official/docs/php/current/billing/create-ep-credit-card.php
@@ -1,10 +1,10 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $referralUserApiKey = $_ENV['REFERRAL_USER_PROD_API_KEY'];
 
-$creditCard = Referral::addCreditCard(
+$creditCard = $client->referralCustomer->addCreditCard(
     $referralUserApiKey,
     '0123456789101234',
     '01',

--- a/official/docs/php/current/billing/delete.php
+++ b/official/docs/php/current/billing/delete.php
@@ -1,7 +1,5 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$success = \EasyPost\Billing::delete_payment_method('primary');
-
-echo $success;
+$client->billing->deletePaymentMethod('primary');

--- a/official/docs/php/current/billing/fund.php
+++ b/official/docs/php/current/billing/fund.php
@@ -1,7 +1,5 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$success = \EasyPost\Billing::fund_wallet(2000, 'primary');
-
-echo $success;
+$client->billing->fundWallet(2000, 'primary');

--- a/official/docs/php/current/billing/list.php
+++ b/official/docs/php/current/billing/list.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$paymentMethods = \EasyPost\Billing::retrieve_payment_methods();
+$paymentMethods = $client->billing->retrievePaymentMethods();
 
 echo $paymentMethods;

--- a/official/docs/php/current/brand/update.php
+++ b/official/docs/php/current/brand/update.php
@@ -1,11 +1,12 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$user = \EasyPost\User::retrieve_me();
+$user = $client->user->retrieveMe();
 
-$brand = $user->update_brand([
-    'color' => '#303F9F',
-]);
+$brand = $client->$user->updateBrand(
+    $user->id,
+    ['color' => '#303F9F']
+);
 
 echo $brand;

--- a/official/docs/php/current/carbon-offset/buy.php
+++ b/official/docs/php/current/carbon-offset/buy.php
@@ -1,15 +1,16 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
-$shipment->buy(
+$boughtShipment = $client->$shipment->buy(
+    $shipment->id,
     [
-        'rate'      => $shipment->lowest_rate(),
+        'rate'      => $shipment->lowestRate(),
         'insurance' => 249.99
     ],
     true
 );
 
-echo $shipment;
+echo $boughtShipment;

--- a/official/docs/php/current/carbon-offset/create.php
+++ b/official/docs/php/current/carbon-offset/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::create(
+$shipment = $client->shipment->create(
     [
         'to_address' => [
             'name' => 'Dr. Steve Brule',

--- a/official/docs/php/current/carbon-offset/one-call-buy.php
+++ b/official/docs/php/current/carbon-offset/one-call-buy.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::create(
+$shipment = $client->shipment->create(
     [
         'carrier_accounts' => ['ca_...'],
         'service' => 'NextDayAir',

--- a/official/docs/php/current/carrier-accounts/create.php
+++ b/official/docs/php/current/carrier-accounts/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$carrierAccount = \EasyPost\CarrierAccount::create([
+$carrierAccount = $client->carrierAccount->create([
     'type' => 'DhlEcsAccount',
     'description' => 'CA Location DHL eCommerce Solutions Account',
     'credentials' => [

--- a/official/docs/php/current/carrier-accounts/delete.php
+++ b/official/docs/php/current/carrier-accounts/delete.php
@@ -1,9 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$carrierAccount = \EasyPost\CarrierAccount::retrieve('ca_...');
+$carrierAccount = $client->carrierAccount->retrieve('ca_...');
 
-$carrierAccount->delete();
-
-echo $carrierAccount;
+$client->$carrierAccount->delete($carrierAccount->id);

--- a/official/docs/php/current/carrier-accounts/list.php
+++ b/official/docs/php/current/carrier-accounts/list.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$carrierAccounts = \EasyPost\CarrierAccount::all();
+$carrierAccounts = $client->carrierAccount->all();
 
 echo $carrierAccounts;

--- a/official/docs/php/current/carrier-accounts/retrieve.php
+++ b/official/docs/php/current/carrier-accounts/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$carrierAccount = \EasyPost\CarrierAccount::retrieve('ca_...');
+$carrierAccount = $client->carrierAccount->retrieve('ca_...');
 
 echo $carrierAccount;

--- a/official/docs/php/current/carrier-accounts/update.php
+++ b/official/docs/php/current/carrier-accounts/update.php
@@ -1,9 +1,12 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$carrierAccount->credentials['pickup_id'] = 'abc123';
+$carrierAccount = $client->carrierAccount->retrieve('ca_...');
 
-$carrierAccount->save();
+$updatedCarrierAccount = $client->$carrierAccount->update(
+    $carrierAccount->id,
+    ['pickup_id' => 'abc123']
+);
 
-echo $carrierAccount;
+echo $updatedCarrierAccount;

--- a/official/docs/php/current/carrier-types/list.php
+++ b/official/docs/php/current/carrier-types/list.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$carrierTypes = \EasyPost\CarrierAccount::types();
+$carrierTypes = $client->carrierAccount->types();
 
 echo $carrierTypes;

--- a/official/docs/php/current/child-users/create.php
+++ b/official/docs/php/current/child-users/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$child = \EasyPost\User::create([
+$child = $client->user->create([
     'name' => 'Child Account Name'
 ]);
 

--- a/official/docs/php/current/child-users/delete.php
+++ b/official/docs/php/current/child-users/delete.php
@@ -1,9 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$user = \EasyPost\User::retrieve('user_...');
+$user = $client->user->retrieve('user_...');
 
-$user->delete();
-
-echo $user;
+$client->$user->delete($user->id);

--- a/official/docs/php/current/customs-infos/create.php
+++ b/official/docs/php/current/customs-infos/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$customsInfo = \EasyPost\CustomsInfo::create([
+$customsInfo = $client->customsInfo->create([
     'eel_pfc' => 'NOEEI 30.37(a)',
     'customs_certify' => true,
     'customs_signer' => 'Steve Brule',

--- a/official/docs/php/current/customs-infos/retrieve.php
+++ b/official/docs/php/current/customs-infos/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$customsInfo = \EasyPost\CustomsInfo::retrieve('cstinfo_...');
+$customsInfo = $client->customsInfo->retrieve('cstinfo_...');
 
 echo $customsInfo;

--- a/official/docs/php/current/customs-items/create.php
+++ b/official/docs/php/current/customs-items/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$customsItem = \EasyPost\CustomsItem::create([
+$customsItem = $client->customsItem->create([
     'description' => 'T-shirt',
     'quantity' => 1,
     'weight' => 5,

--- a/official/docs/php/current/customs-items/retrieve.php
+++ b/official/docs/php/current/customs-items/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$customsItem = \EasyPost\CustomsItem::retrieve('cstitem_...');
+$customsItem = $client->customsItem->retrieve('cstitem_...');
 
 echo $customsItem;

--- a/official/docs/php/current/endshipper/buy.php
+++ b/official/docs/php/current/endshipper/buy.php
@@ -1,14 +1,17 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
-$shipment->buy([
-    'rate'      => $shipment->lowest_rate(),
-    'insurance' => null,
-    'with_carbon_offset' => false,
-    'end_shipper_id' => 'es_...'
-]);
+$boughtShipment = $client->$shipment->buy(
+    $shipment->id,
+    [
+        'rate'      => $shipment->lowestRate(),
+        'insurance' => null,
+        'with_carbon_offset' => false,
+        'end_shipper_id' => 'es_...'
+    ]
+);
 
-echo $shipment;
+echo $boughtShipment;

--- a/official/docs/php/current/endshipper/create.php
+++ b/official/docs/php/current/endshipper/create.php
@@ -1,6 +1,6 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $params = [
     'name' => 'FOO BAR',
@@ -15,6 +15,6 @@ $params = [
     'email' => 'FOO@EXAMPLE.COM'
 ];
 
-$endshipper = \EasyPost\EndShipper::create($params);
+$endshipper = $client->endShipper->create($params);
 
 echo $endshipper;

--- a/official/docs/php/current/endshipper/list.php
+++ b/official/docs/php/current/endshipper/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$endshippers = \EasyPost\EndShipper::all([
+$endshippers = $client->endShipper->all([
     'page_size' => 5
 ]);
 

--- a/official/docs/php/current/endshipper/retrieve.php
+++ b/official/docs/php/current/endshipper/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$endshipper = \EasyPost\EndShipper::retrieve('es_...');
+$endshipper = $client->endShipper->retrieve('es_...');
 
 echo $endshipper;

--- a/official/docs/php/current/endshipper/update.php
+++ b/official/docs/php/current/endshipper/update.php
@@ -1,20 +1,23 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$endshipper = \EasyPost\EndShipper::retrieve('es_...');
+$endshipper = $client->endShipper->retrieve('es_...');
 
-$endshipper->name = 'NEW NAME';
-$endshipper->company = 'BAZ';
-$endshipper->street1 = '164 TOWNSEND STREET UNIT 1';
-$endshipper->street2 = 'UNIT 1';
-$endshipper->city = 'SAN FRANCISCO';
-$endshipper->state = 'CA';
-$endshipper->zip = '94107';
-$endshipper->country = 'US';
-$endshipper->phone = '555-555-5555';
-$endshipper->email = 'FOO@EXAMPLE.COM';
+$updatedEndShipper = $client->$endShipper->update(
+    $endShipper->id,
+    [
+        'name' => 'NEW NAME',
+        'company' => 'BAZ',
+        'street1' => '164 TOWNSEND STREET UNIT 1',
+        'street2' => 'UNIT 1',
+        'city' => 'SAN FRANCISCO',
+        'state' => 'CA',
+        'zip' => '94107',
+        'country' => 'US',
+        'phone' => '555-555-5555',
+        'email' => 'FOO@EXAMPLE.COM',
+    ]
+);
 
-$endShipper->save();
-
-echo $endShipper;
+echo $updatedEndShipper;

--- a/official/docs/php/current/events/list.php
+++ b/official/docs/php/current/events/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$events = \EasyPost\Event::all([
+$events = $client->event->all([
     'page_size' => 5
 ]);
 

--- a/official/docs/php/current/events/retrieve.php
+++ b/official/docs/php/current/events/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$event = \EasyPost\Event::retrieve('evt_...');
+$event = $client->event->retrieve('evt_...');
 
 echo $event;

--- a/official/docs/php/current/forms/create.php
+++ b/official/docs/php/current/forms/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
 $formType = 'return_packing_slip';
 $formOptions = [
@@ -18,6 +18,6 @@ $formOptions = [
     ],
 ];
 
-$shipment->generate_form($formType, $formOptions);
+$shipmentWithForm = $client->$shipment->generateForm($shipment->id, $formType, $formOptions);
 
-echo $shipment;
+echo $shipmentWithForm;

--- a/official/docs/php/current/insurance/create.php
+++ b/official/docs/php/current/insurance/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$insurance = \EasyPost\Insurance::create([
+$insurance = $client->insurance->create([
     'to_address' => ['id' => 'adr_...'],
     'from_address' => ['id' => 'adr_...'],
     'tracking_code' => '9400110898825022579493',

--- a/official/docs/php/current/insurance/list.php
+++ b/official/docs/php/current/insurance/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$insurances = \EasyPost\Insurance::all([
+$insurances = $client->insurance->all([
     'page_size' => 5,
 ]);
 

--- a/official/docs/php/current/insurance/retrieve.php
+++ b/official/docs/php/current/insurance/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$insurance = \EasyPost\Insurance::retrieve('ins_...');
+$insurance = $client->insurance->retrieve('ins_...');
 
 echo $insurance;

--- a/official/docs/php/current/options/create-with-options.php
+++ b/official/docs/php/current/options/create-with-options.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::create([
+$shipment = $client->shipment->create([
     'to_address' => ['id' => 'adr_...'],
     'from_address' => ['id' => 'adr_...'],
     'parcel' => [

--- a/official/docs/php/current/orders/buy.php
+++ b/official/docs/php/current/orders/buy.php
@@ -1,12 +1,15 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$order = \EasyPost\Order::retrieve('order_...');
+$order = $client->order->retrieve('order_...');
 
-$order->buy([
-    'carrier' => 'FedEx',
-    'service' => 'FEDEX_GROUND'
-]);
+$boughtOrder = $client->$order->buy(
+    $shipment->id,
+    [
+        'carrier' => 'FedEx',
+        'service' => 'FEDEX_GROUND'
+    ]
+);
 
-echo $order;
+echo $boughtOrder;

--- a/official/docs/php/current/orders/create.php
+++ b/official/docs/php/current/orders/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$order = \EasyPost\Order::create([
+$order = $client->order->create([
     'to_address' => ['id' => 'adr_...'],
     'from_address' => ['id' => 'adr_...'],
     'shipments' => [

--- a/official/docs/php/current/orders/one-call-buy.php
+++ b/official/docs/php/current/orders/one-call-buy.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$order = \EasyPost\Order::create([
+$order = $client->order->create([
     'carrier_accounts' => 'ca_...',
     'service' => 'NextDayAir',
     'to_address' => ['id' => 'adr_...'],

--- a/official/docs/php/current/orders/retrieve.php
+++ b/official/docs/php/current/orders/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$order = \EasyPost\Order::retrieve('order_...');
+$order = $client->order->retrieve('order_...');
 
 echo $order;

--- a/official/docs/php/current/parcels/create.php
+++ b/official/docs/php/current/parcels/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$parcel = \EasyPost\Parcel::create([
+$parcel = $client->parcel->create([
     'length' => 20.2,
     'width' => 10.9,
     'height' => 5,

--- a/official/docs/php/current/parcels/retrieve.php
+++ b/official/docs/php/current/parcels/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$parcel = \EasyPost\Parcel::retrieve('prcl_...');
+$parcel = $client->parcel->retrieve('prcl_...');
 
 echo $parcel;

--- a/official/docs/php/current/pickups/buy.php
+++ b/official/docs/php/current/pickups/buy.php
@@ -1,12 +1,15 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$pickup = \EasyPost\Pickup::retrieve('pickup_...');
+$pickup = $client->pickup->retrieve('pickup_...');
 
-$pickup->buy([
-    'carrier' => 'UPS',
-    'service' => 'Same-day Pickup'
-]);
+$boughtPickup = $client->$pickup->buy(
+    $pickup->id,
+    [
+        'carrier' => 'UPS',
+        'service' => 'Same-day Pickup'
+    ]
+);
 
 echo $pickup;

--- a/official/docs/php/current/pickups/cancel.php
+++ b/official/docs/php/current/pickups/cancel.php
@@ -1,9 +1,9 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$pickup = \EasyPost\Pickup::retrieve('pickup_...');
+$pickup = $client->pickup->retrieve('pickup_...');
 
-$pickup->cancel();
+$cancelledPickup = $client->$pickup->cancel($pickup->id);
 
-echo $pickup;
+echo $cancelledPickup;

--- a/official/docs/php/current/pickups/create.php
+++ b/official/docs/php/current/pickups/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$pickup = \EasyPost\Pickup::create([
+$pickup = $client->pickup->create([
     'address' => ['id' => 'adr_...'],
     'shipment' => ['id' => 'shp_...'],
     'reference' => 'my-first-pickup',

--- a/official/docs/php/current/pickups/retrieve.php
+++ b/official/docs/php/current/pickups/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$pickup = \EasyPost\Pickup::retrieve('pickup_...');
+$pickup = $client->pickup->retrieve('pickup_...');
 
 echo $pickup;

--- a/official/docs/php/current/rates/regenerate.php
+++ b/official/docs/php/current/rates/regenerate.php
@@ -1,9 +1,9 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
-$shipment->regenerate_rates();
+$shipmentWithRegeneratedrates = $client->$shipment->regenerateRates($shipment->id);
 
-echo $shipment;
+echo $shipmentWithRegeneratedrates;

--- a/official/docs/php/current/rates/retrieve.php
+++ b/official/docs/php/current/rates/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$rate = \EasyPost\Rate::retrieve('rate...');
+$rate = $client->rate->retrieve('rate...');
 
 echo $rate;

--- a/official/docs/php/current/referral-customers/create.php
+++ b/official/docs/php/current/referral-customers/create.php
@@ -1,11 +1,11 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$referralUser = Referral::create([
-  'name' => 'Test Referral',
-  'email' => 'test@test.com',
-  'phone' => '8888888888'
+$referralUser = $client->referralCustomer->create([
+    'name' => 'Test Referral',
+    'email' => 'test@test.com',
+    'phone' => '8888888888'
 ]);
 
 echo $referralUser;

--- a/official/docs/php/current/referral-customers/list.php
+++ b/official/docs/php/current/referral-customers/list.php
@@ -1,9 +1,9 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$referralUsers = Referral::all([
-  'page_size' => 5,
+$referralUsers = $client->referralCustomer->all([
+    'page_size' => 5,
 ]);
 
 echo $referralUsers;

--- a/official/docs/php/current/referral-customers/update.php
+++ b/official/docs/php/current/referral-customers/update.php
@@ -1,5 +1,5 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-Referral::update_email('new_email@example.com', 'user_...');
+$client->referralCustomer->updateEmail('new_email@example.com', 'user_...');

--- a/official/docs/php/current/refunds/create.php
+++ b/official/docs/php/current/refunds/create.php
@@ -1,9 +1,9 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
-$shipment->refund();
+$refundedShipment = $client->$shipment->refund($shipment->id);
 
-echo $shipment;
+echo $refundedShipment;

--- a/official/docs/php/current/reports/create.php
+++ b/official/docs/php/current/reports/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$report = \EasyPost\Report::create([
+$report = $client->report->create([
     'start_date' => '2022-10-01',
     'end_date' => '2022-10-31',
 ]);

--- a/official/docs/php/current/reports/list.php
+++ b/official/docs/php/current/reports/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$reports = \EasyPost\Report::all([
+$reports = $client->report->all([
     // Replace `payment_log` with any of the report types listed above
     'type' => 'payment_log',
     'page_size' => 5,

--- a/official/docs/php/current/reports/retrieve.php
+++ b/official/docs/php/current/reports/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$report = \EasyPost\Report::retrieve('<REPORT_ID>');
+$report = $client->report->retrieve('<REPORT_ID>');
 
 echo $report;

--- a/official/docs/php/current/returns/create.php
+++ b/official/docs/php/current/returns/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::create([
+$shipment = $client->shipment->create([
     'to_address' => [
         'name' => 'Dr. Steve Brule',
         'street1' => '179 N Harbor Dr',

--- a/official/docs/php/current/scan-form/create.php
+++ b/official/docs/php/current/scan-form/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$scanForm = \EasyPost\ScanForm::create([
+$scanForm = $client->scanForm->create([
     'shipments' => [
         ['id' => 'shp_...'],
         ['id' => 'shp_...'],

--- a/official/docs/php/current/scan-form/list.php
+++ b/official/docs/php/current/scan-form/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$scanForms = \EasyPost\ScanForm::all([
+$scanForms = $client->scanForm->all([
     'page_size' => 5
 ]);
 

--- a/official/docs/php/current/scan-form/retrieve.php
+++ b/official/docs/php/current/scan-form/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$scanForm = \EasyPost\ScanForm::retrieve('sf_...');
+$scanForm = $client->scanForm->retrieve('sf_...');
 
 echo $scanForm;

--- a/official/docs/php/current/shipments/buy.php
+++ b/official/docs/php/current/shipments/buy.php
@@ -1,12 +1,15 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
-$shipment->buy([
-    'rate'      => $shipment->lowest_rate(),
-    'insurance' => 249.99
-]);
+$boughtShipment = $client->$shipment->buy(
+    $shipment->id,
+    [
+        'rate'      => $shipment->lowestRate(),
+        'insurance' => 249.99
+    ]
+);
 
-echo $shipment;
+echo $boughtShipment;

--- a/official/docs/php/current/shipments/create.php
+++ b/official/docs/php/current/shipments/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::create([
+$shipment = $client->shipment->create([
     'to_address' => [
         'name' => 'Dr. Steve Brule',
         'street1' => '179 N Harbor Dr',

--- a/official/docs/php/current/shipments/label.php
+++ b/official/docs/php/current/shipments/label.php
@@ -1,10 +1,12 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
-$shipment->label([
-    'file_format' => 'ZPL'
-]);
+$shipment = $client->shipment->retrieve('shp_...');
+
+$shipmentWithLabel = $client->$shipment->label(
+    $shipment->id,
+    ['file_format' => 'ZPL']
+);
 
 echo $shipment;

--- a/official/docs/php/current/shipments/list.php
+++ b/official/docs/php/current/shipments/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipments = \EasyPost\Shipment::all([
+$shipments = $client->shipment->all([
     'page_size' => 5,
 ]);
 

--- a/official/docs/php/current/shipments/one-call-buy.php
+++ b/official/docs/php/current/shipments/one-call-buy.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::create([
+$shipment = $client->shipment->create([
     'carrier_accounts' => ['ca_...'],
     'service' => 'NextDayAir',
     'to_address' => [

--- a/official/docs/php/current/shipments/retrieve.php
+++ b/official/docs/php/current/shipments/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
 echo $shipment;

--- a/official/docs/php/current/shipping-insurance/insure.php
+++ b/official/docs/php/current/shipping-insurance/insure.php
@@ -1,9 +1,12 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
-$shipment->insure(['amount' => 100]);
+$shipmentWithInsurance = $client->$shipment->insure(
+    $shipment->id,
+    ['amount' => 100]
+);
 
-echo $shipment;
+echo $shipmentWithInsurance;

--- a/official/docs/php/current/smartrate/retrieve-time-in-transit-statistics.php
+++ b/official/docs/php/current/smartrate/retrieve-time-in-transit-statistics.php
@@ -1,9 +1,9 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment = $client->shipment->retrieve('shp_...');
 
-$shipment->get_smartrates();
+$smartRates = $client->$shipment->getSmartrates();
 
-echo $shipment;
+echo $smartRates;

--- a/official/docs/php/current/tax-identifiers/create.php
+++ b/official/docs/php/current/tax-identifiers/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$shipment = \EasyPost\Shipment::create([
+$shipment = $client->shipment->create([
     'to_address' => [
         'name' => 'Dr. Steve Brule',
         'street1' => '179 N Harbor Dr',

--- a/official/docs/php/current/trackers/create.php
+++ b/official/docs/php/current/trackers/create.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$tracker = \EasyPost\Tracker::create([
+$tracker = $client->tracker->create([
     'tracking_code' => 'EZ1000000001',
     'carrier' => 'USPS'
 ]);

--- a/official/docs/php/current/trackers/list.php
+++ b/official/docs/php/current/trackers/list.php
@@ -1,8 +1,8 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$trackers = \EasyPost\Tracker::all([
+$trackers = $client->tracker->all([
     'page_size' => 5,
 ]);
 

--- a/official/docs/php/current/trackers/retrieve.php
+++ b/official/docs/php/current/trackers/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$tracker = \EasyPost\Tracker::retrieve('trk_...');
+$tracker = $client->tracker->retrieve('trk_...');
 
 echo $tracker;

--- a/official/docs/php/current/users/retrieve.php
+++ b/official/docs/php/current/users/retrieve.php
@@ -1,11 +1,11 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 // Retrieve the authenticated user
-$user = \EasyPost\User::retrieve_me();
+$user = $client->user->retrieveMe();
 
 // Retrieve a child user
-$user = \EasyPost\User::retrieve('user_...');
+$user = $client->user->retrieve('user_...');
 
 echo $user;

--- a/official/docs/php/current/users/update.php
+++ b/official/docs/php/current/users/update.php
@@ -1,11 +1,12 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$user = \EasyPost\User::retrieve_me();
+$user = $client->user->retrieveMe();
 
-$user->recharge_threshold = '50.00';
+$updatedUser = $client->$user->update(
+    $user->id,
+    ['recharge_threshold' => '50.00']
+);
 
-$user->save();
-
-echo $user;
+echo $updatedUser;

--- a/official/docs/php/current/webhooks/create.php
+++ b/official/docs/php/current/webhooks/create.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$webhook = \EasyPost\Webhook::create(['url' => 'example.com']);
+$webhook = $client->webhook->create(['url' => 'example.com']);
 
 echo $webhook;

--- a/official/docs/php/current/webhooks/delete.php
+++ b/official/docs/php/current/webhooks/delete.php
@@ -1,9 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$webhook = \EasyPost\Webhook::retrieve('hook_...');
+$webhook = $client->webhook->retrieve('hook_...');
 
-$webhook->delete();
-
-echo $webhook;
+$client->$webhook->delete($webhook->id);

--- a/official/docs/php/current/webhooks/list.php
+++ b/official/docs/php/current/webhooks/list.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$webhooks = \EasyPost\Webhook::all();
+$webhooks = $client->webhook->all();
 
 echo $webhooks;

--- a/official/docs/php/current/webhooks/retrieve.php
+++ b/official/docs/php/current/webhooks/retrieve.php
@@ -1,7 +1,7 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$webhook = \EasyPost\Webhook::retrieve('hook_...');
+$webhook = $client->webhook->retrieve('hook_...');
 
 echo $webhook;

--- a/official/docs/php/current/webhooks/update.php
+++ b/official/docs/php/current/webhooks/update.php
@@ -1,9 +1,9 @@
 <?php
 
-\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+$client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-$webhook = \EasyPost\Webhook::retrieve('hook_...');
+$webhook = $client->webhook->retrieve('hook_...');
 
-$webhook->update();
+$updatedWebhook = $client->$webhook->update();
 
-echo $webhook;
+echo $updatedWebhook;

--- a/official/docs/php/v5/addresses/create-and-verify.php
+++ b/official/docs/php/v5/addresses/create-and-verify.php
@@ -1,0 +1,16 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$address = \EasyPost\Address::create_and_verify([
+    'street1' => '417 Montgomery Street',
+    'street2' => 'FL 5',
+    'city'    => 'San Francisco',
+    'state'   => 'CA',
+    'zip'     => '94104',
+    'country' => 'US',
+    'company' => 'EasyPost',
+    'phone'   => '415-123-4567'
+]);
+
+echo $address;

--- a/official/docs/php/v5/addresses/create.php
+++ b/official/docs/php/v5/addresses/create.php
@@ -1,0 +1,16 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$address = \EasyPost\Address::create([
+    'street1' => '417 MONTGOMERY ST',
+    'street2' => 'FLOOR 5',
+    'city'    => 'San Francisco',
+    'state'   => 'CA',
+    'zip'     => '94104',
+    'country' => 'US',
+    'company' => 'EasyPost',
+    'phone'   => '415-123-4567'
+]);
+
+echo $address;

--- a/official/docs/php/v5/addresses/list.php
+++ b/official/docs/php/v5/addresses/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$addresses = \EasyPost\Address::all([
+    'page_size' => 5
+]);
+
+echo $addresses;

--- a/official/docs/php/v5/addresses/retrieve.php
+++ b/official/docs/php/v5/addresses/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$address = \EasyPost\Address::retrieve('adr_...');
+
+echo $address;

--- a/official/docs/php/v5/addresses/verify-failure.php
+++ b/official/docs/php/v5/addresses/verify-failure.php
@@ -1,0 +1,15 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$address = \EasyPost\Address::create([
+    'street1' => 'UNDELIVERABLE ST',
+    'city'    => 'San Francisco',
+    'state'   => 'CA',
+    'zip'     => '94104',
+    'country' => 'US',
+    'company' => 'EasyPost',
+    'phone'   => '415-123-4567'
+]);
+
+echo $address;

--- a/official/docs/php/v5/addresses/verify-param.php
+++ b/official/docs/php/v5/addresses/verify-param.php
@@ -1,0 +1,17 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$address = \EasyPost\Address::create([
+    'verify'  => true,
+    'street1' => '417 Montgomery Streat',
+    'street2' => '5',
+    'city'    => 'SF',
+    'state'   => 'CA',
+    'zip'     => '94104',
+    'country' => 'US',
+    'company' => 'EasyPost',
+    'phone'   => '415-123-4567'
+]);
+
+echo $address;

--- a/official/docs/php/v5/addresses/verify-strict-param.php
+++ b/official/docs/php/v5/addresses/verify-strict-param.php
@@ -1,0 +1,17 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$address = \EasyPost\Address::create([
+    'verify_strict'  => true,
+    'street1'        => '417 MONTGOMERY ST',
+    'street2'        => 'FL 5',
+    'city'           => 'San Francisco',
+    'state'          => 'CA',
+    'zip'            => '94104',
+    'country'        => 'US',
+    'company'        => 'EasyPost',
+    'phone'          => '415-123-4567'
+]);
+
+echo $address;

--- a/official/docs/php/v5/addresses/verify.php
+++ b/official/docs/php/v5/addresses/verify.php
@@ -1,0 +1,18 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$address = \EasyPost\Address::create([
+    'street1' => '417 montgomery streat',
+    'street2' => 'FL 5',
+    'city'    => 'San Francisco',
+    'state'   => 'CA',
+    'zip'     => '94104',
+    'country' => 'US',
+    'company' => 'EasyPost',
+    'phone'   => '415-123-4567'
+]);
+
+$address->verify();
+
+echo $address;

--- a/official/docs/php/v5/api-keys/retrieve.php
+++ b/official/docs/php/v5/api-keys/retrieve.php
@@ -1,0 +1,12 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+// Retrieve all API keys (authenticated user and child user keys)
+$apiKeys = \EasyPost\User::all_api_keys();
+
+// Retrieve API keys for a child user
+$childUser = \EasyPost\User::retrieve('user_...');
+$apiKeys = $childUser->api_keys();
+
+echo $apiKeys;

--- a/official/docs/php/v5/batches/add-shipments.php
+++ b/official/docs/php/v5/batches/add-shipments.php
@@ -1,0 +1,14 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$batch = \EasyPost\Batch::retrieve('batch_...');
+
+$batch->add_shipments([
+    'shipments' => [
+        ['id' => 'shp_...'],
+        ['id' => 'shp_...'],
+    ]
+]);
+
+echo $batch;

--- a/official/docs/php/v5/batches/buy.php
+++ b/official/docs/php/v5/batches/buy.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$batch = \EasyPost\Batch::retrieve('batch_...');
+
+$batch->buy();
+
+echo $batch;

--- a/official/docs/php/v5/batches/create.php
+++ b/official/docs/php/v5/batches/create.php
@@ -1,0 +1,12 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$batch = \EasyPost\Batch::create([
+    'shipments' => [
+        ['id' => 'shp_...'],
+        ['id' => 'shp_...'],
+    ]
+]);
+
+echo $batch;

--- a/official/docs/php/v5/batches/label.php
+++ b/official/docs/php/v5/batches/label.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$batch = \EasyPost\Batch::retrieve('batch_...');
+
+$batch->label(['file_format' => 'PDF']);
+
+echo $batch;

--- a/official/docs/php/v5/batches/list.php
+++ b/official/docs/php/v5/batches/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$batches = \EasyPost\Batch::all([
+    'page_size' => 5,
+]);
+
+echo $batches;

--- a/official/docs/php/v5/batches/remove-shipments.php
+++ b/official/docs/php/v5/batches/remove-shipments.php
@@ -1,0 +1,13 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$batch = \EasyPost\Batch::retrieve('batch_...');
+
+$batch->remove_shipments([
+    'shipments' => [
+        ['id' => 'shp_...']
+    ]
+]);
+
+echo $batch;

--- a/official/docs/php/v5/batches/retrieve.php
+++ b/official/docs/php/v5/batches/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$batch = \EasyPost\Batch::retrieve('batch_...');
+
+echo $batch;

--- a/official/docs/php/v5/batches/scan-forms.php
+++ b/official/docs/php/v5/batches/scan-forms.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$batch = \EasyPost\Batch::retrieve('batch_...');
+
+$batch->create_scan_form();
+
+echo $batch;

--- a/official/docs/php/v5/billing/create-ep-credit-card.php
+++ b/official/docs/php/v5/billing/create-ep-credit-card.php
@@ -1,0 +1,15 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$referralUserApiKey = $_ENV['REFERRAL_USER_PROD_API_KEY'];
+
+$creditCard = Referral::addCreditCard(
+    $referralUserApiKey,
+    '0123456789101234',
+    '01',
+    '2025',
+    '111'
+);
+
+echo $creditCard;

--- a/official/docs/php/v5/billing/delete.php
+++ b/official/docs/php/v5/billing/delete.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$success = \EasyPost\Billing::delete_payment_method('primary');
+
+echo $success;

--- a/official/docs/php/v5/billing/fund.php
+++ b/official/docs/php/v5/billing/fund.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$success = \EasyPost\Billing::fund_wallet(2000, 'primary');
+
+echo $success;

--- a/official/docs/php/v5/billing/list.php
+++ b/official/docs/php/v5/billing/list.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$paymentMethods = \EasyPost\Billing::retrieve_payment_methods();
+
+echo $paymentMethods;

--- a/official/docs/php/v5/brand/update.php
+++ b/official/docs/php/v5/brand/update.php
@@ -1,0 +1,11 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$user = \EasyPost\User::retrieve_me();
+
+$brand = $user->update_brand([
+    'color' => '#303F9F',
+]);
+
+echo $brand;

--- a/official/docs/php/v5/carbon-offset/buy.php
+++ b/official/docs/php/v5/carbon-offset/buy.php
@@ -1,0 +1,15 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+$shipment->buy(
+    [
+        'rate'      => $shipment->lowest_rate(),
+        'insurance' => 249.99
+    ],
+    true
+);
+
+echo $shipment;

--- a/official/docs/php/v5/carbon-offset/create.php
+++ b/official/docs/php/v5/carbon-offset/create.php
@@ -1,0 +1,39 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::create(
+    [
+        'to_address' => [
+            'name' => 'Dr. Steve Brule',
+            'street1' => '179 N Harbor Dr',
+            'city' => 'Redondo Beach',
+            'state' => 'CA',
+            'zip' => '90277',
+            'country' => 'US',
+            'phone' => '3331114444',
+            'email' => 'dr_steve_brule@gmail.com'
+        ],
+        'from_address' => [
+            'name' => 'EasyPost',
+            'street1' => '417 Montgomery Street',
+            'street2' => '5th Floor',
+            'city' => 'San Francisco',
+            'state' => 'CA',
+            'zip' => '94104',
+            'country' => 'US',
+            'phone' => '3331114444',
+            'email' => 'support@easypost.com'
+        ],
+        'parcel' => [
+            'length' => 20.2,
+            'width' => 10.9,
+            'height' => 5,
+            'weight' => 65.9
+        ]
+    ],
+    null,
+    true
+);
+
+echo $shipment;

--- a/official/docs/php/v5/carbon-offset/one-call-buy.php
+++ b/official/docs/php/v5/carbon-offset/one-call-buy.php
@@ -1,0 +1,41 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::create(
+    [
+        'carrier_accounts' => ['ca_...'],
+        'service' => 'NextDayAir',
+        'to_address' => [
+            'name' => 'Dr. Steve Brule',
+            'street1' => '179 N Harbor Dr',
+            'city' => 'Redondo Beach',
+            'state' => 'CA',
+            'zip' => '90277',
+            'country' => 'US',
+            'phone' => '3331114444',
+            'email' => 'dr_steve_brule@gmail.com'
+        ],
+        'from_address' => [
+            'name' => 'EasyPost',
+            'street1' => '417 Montgomery Street',
+            'street2' => '5th Floor',
+            'city' => 'San Francisco',
+            'state' => 'CA',
+            'zip' => '94104',
+            'country' => 'US',
+            'phone' => '3331114444',
+            'email' => 'support@easypost.com'
+        ],
+        'parcel' => [
+            'length' => 20.2,
+            'width' => 10.9,
+            'height' => 5,
+            'weight' => 65.9
+        ]
+    ],
+    null,
+    true
+);
+
+echo $shipment;

--- a/official/docs/php/v5/carrier-accounts/create.php
+++ b/official/docs/php/v5/carrier-accounts/create.php
@@ -1,0 +1,22 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$carrierAccount = \EasyPost\CarrierAccount::create([
+    'type' => 'DhlEcsAccount',
+    'description' => 'CA Location DHL eCommerce Solutions Account',
+    'credentials' => [
+        'client_id' => '123456',
+        'client_secret' => '123abc',
+        'distribution_center' => 'USLAX1',
+        'pickup_id' => '123456'
+    ],
+    'test_credentials' => [
+        'client_id' => '123456',
+        'client_secret' => '123abc',
+        'distribution_center' => 'USLAX1',
+        'pickup_id' => '123456'
+    ]
+]);
+
+echo $carrierAccount;

--- a/official/docs/php/v5/carrier-accounts/delete.php
+++ b/official/docs/php/v5/carrier-accounts/delete.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$carrierAccount = \EasyPost\CarrierAccount::retrieve('ca_...');
+
+$carrierAccount->delete();
+
+echo $carrierAccount;

--- a/official/docs/php/v5/carrier-accounts/list.php
+++ b/official/docs/php/v5/carrier-accounts/list.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$carrierAccounts = \EasyPost\CarrierAccount::all();
+
+echo $carrierAccounts;

--- a/official/docs/php/v5/carrier-accounts/retrieve.php
+++ b/official/docs/php/v5/carrier-accounts/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$carrierAccount = \EasyPost\CarrierAccount::retrieve('ca_...');
+
+echo $carrierAccount;

--- a/official/docs/php/v5/carrier-accounts/update.php
+++ b/official/docs/php/v5/carrier-accounts/update.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$carrierAccount->credentials['pickup_id'] = 'abc123';
+
+$carrierAccount->save();
+
+echo $carrierAccount;

--- a/official/docs/php/v5/carrier-types/list.php
+++ b/official/docs/php/v5/carrier-types/list.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$carrierTypes = \EasyPost\CarrierAccount::types();
+
+echo $carrierTypes;

--- a/official/docs/php/v5/child-users/create.php
+++ b/official/docs/php/v5/child-users/create.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$child = \EasyPost\User::create([
+    'name' => 'Child Account Name'
+]);
+
+echo $child;

--- a/official/docs/php/v5/child-users/delete.php
+++ b/official/docs/php/v5/child-users/delete.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$user = \EasyPost\User::retrieve('user_...');
+
+$user->delete();
+
+echo $user;

--- a/official/docs/php/v5/customs-infos/create.php
+++ b/official/docs/php/v5/customs-infos/create.php
@@ -1,0 +1,24 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$customsInfo = \EasyPost\CustomsInfo::create([
+    'eel_pfc' => 'NOEEI 30.37(a)',
+    'customs_certify' => true,
+    'customs_signer' => 'Steve Brule',
+    'contents_type' => 'merchandise',
+    'contents_explanation' => '',
+    'restriction_type' => 'none',
+    'customs_items' => [
+        [
+            'description' => 'T-shirt',
+            'quantity' => 1,
+            'weight' => 5,
+            'value' => 10,
+            'hs_tariff_number' => '123456',
+            'origin_country' => 'US'
+        ]
+    ]
+]);
+
+echo $customsInfo;

--- a/official/docs/php/v5/customs-infos/retrieve.php
+++ b/official/docs/php/v5/customs-infos/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$customsInfo = \EasyPost\CustomsInfo::retrieve('cstinfo_...');
+
+echo $customsInfo;

--- a/official/docs/php/v5/customs-items/create.php
+++ b/official/docs/php/v5/customs-items/create.php
@@ -1,0 +1,14 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$customsItem = \EasyPost\CustomsItem::create([
+    'description' => 'T-shirt',
+    'quantity' => 1,
+    'weight' => 5,
+    'value' => 10,
+    'hs_tariff_number' => '123456',
+    'origin_country' => 'US'
+]);
+
+echo $customsItem;

--- a/official/docs/php/v5/customs-items/retrieve.php
+++ b/official/docs/php/v5/customs-items/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$customsItem = \EasyPost\CustomsItem::retrieve('cstitem_...');
+
+echo $customsItem;

--- a/official/docs/php/v5/endshipper/buy.php
+++ b/official/docs/php/v5/endshipper/buy.php
@@ -1,0 +1,14 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+$shipment->buy([
+    'rate'      => $shipment->lowest_rate(),
+    'insurance' => null,
+    'with_carbon_offset' => false,
+    'end_shipper_id' => 'es_...'
+]);
+
+echo $shipment;

--- a/official/docs/php/v5/endshipper/create.php
+++ b/official/docs/php/v5/endshipper/create.php
@@ -1,0 +1,20 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$params = [
+    'name' => 'FOO BAR',
+    'company' => 'BAZ',
+    'street1' => '164 TOWNSEND STREET UNIT 1',
+    'street2' => 'UNIT 1',
+    'city' => 'SAN FRANCISCO',
+    'state' => 'CA',
+    'zip' => '94107',
+    'country' => 'US',
+    'phone' => '555-555-5555',
+    'email' => 'FOO@EXAMPLE.COM'
+];
+
+$endshipper = \EasyPost\EndShipper::create($params);
+
+echo $endshipper;

--- a/official/docs/php/v5/endshipper/list.php
+++ b/official/docs/php/v5/endshipper/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$endshippers = \EasyPost\EndShipper::all([
+    'page_size' => 5
+]);
+
+echo $endshippers;

--- a/official/docs/php/v5/endshipper/retrieve.php
+++ b/official/docs/php/v5/endshipper/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$endshipper = \EasyPost\EndShipper::retrieve('es_...');
+
+echo $endshipper;

--- a/official/docs/php/v5/endshipper/update.php
+++ b/official/docs/php/v5/endshipper/update.php
@@ -1,0 +1,20 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$endshipper = \EasyPost\EndShipper::retrieve('es_...');
+
+$endshipper->name = 'NEW NAME';
+$endshipper->company = 'BAZ';
+$endshipper->street1 = '164 TOWNSEND STREET UNIT 1';
+$endshipper->street2 = 'UNIT 1';
+$endshipper->city = 'SAN FRANCISCO';
+$endshipper->state = 'CA';
+$endshipper->zip = '94107';
+$endshipper->country = 'US';
+$endshipper->phone = '555-555-5555';
+$endshipper->email = 'FOO@EXAMPLE.COM';
+
+$endShipper->save();
+
+echo $endShipper;

--- a/official/docs/php/v5/events/list.php
+++ b/official/docs/php/v5/events/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$events = \EasyPost\Event::all([
+    'page_size' => 5
+]);
+
+echo $events;

--- a/official/docs/php/v5/events/retrieve.php
+++ b/official/docs/php/v5/events/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$event = \EasyPost\Event::retrieve('evt_...');
+
+echo $event;

--- a/official/docs/php/v5/forms/create.php
+++ b/official/docs/php/v5/forms/create.php
@@ -1,0 +1,23 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+$formType = 'return_packing_slip';
+$formOptions = [
+    'barcode' => 'RMA12345678900',
+    'line_items' => [
+        [
+            'product' => [
+                'title' => 'Square Reader',
+                'barcode' => '855658003251',
+            ],
+            'units' => 8,
+        ],
+    ],
+];
+
+$shipment->generate_form($formType, $formOptions);
+
+echo $shipment;

--- a/official/docs/php/v5/insurance/create.php
+++ b/official/docs/php/v5/insurance/create.php
@@ -1,0 +1,14 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$insurance = \EasyPost\Insurance::create([
+    'to_address' => ['id' => 'adr_...'],
+    'from_address' => ['id' => 'adr_...'],
+    'tracking_code' => '9400110898825022579493',
+    'carrier' => 'USPS',
+    'amount' => '100.00',
+    'reference' => 'insuranceRef1'
+]);
+
+echo $insurance;

--- a/official/docs/php/v5/insurance/list.php
+++ b/official/docs/php/v5/insurance/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$insurances = \EasyPost\Insurance::all([
+    'page_size' => 5,
+]);
+
+echo $insurances;

--- a/official/docs/php/v5/insurance/retrieve.php
+++ b/official/docs/php/v5/insurance/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$insurance = \EasyPost\Insurance::retrieve('ins_...');
+
+echo $insurance;

--- a/official/docs/php/v5/options/create-with-options.php
+++ b/official/docs/php/v5/options/create-with-options.php
@@ -1,0 +1,17 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::create([
+    'to_address' => ['id' => 'adr_...'],
+    'from_address' => ['id' => 'adr_...'],
+    'parcel' => [
+        'length' => 20.2,
+        'width' => 10.9,
+        'height' => 5,
+        'weight' => 65.9
+    ],
+    'options' => ['print_custom_1' => 'Custom label message']
+]);
+
+echo $shipment;

--- a/official/docs/php/v5/orders/buy.php
+++ b/official/docs/php/v5/orders/buy.php
@@ -1,0 +1,12 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$order = \EasyPost\Order::retrieve('order_...');
+
+$order->buy([
+    'carrier' => 'FedEx',
+    'service' => 'FEDEX_GROUND'
+]);
+
+echo $order;

--- a/official/docs/php/v5/orders/create.php
+++ b/official/docs/php/v5/orders/create.php
@@ -1,0 +1,23 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$order = \EasyPost\Order::create([
+    'to_address' => ['id' => 'adr_...'],
+    'from_address' => ['id' => 'adr_...'],
+    'shipments' => [
+        [
+            'parcel' => [
+                'weight' => 10.2
+            ]
+        ],
+        [
+            'parcel' => [
+                'predefined_package' => 'FedExBox',
+                'weight' => 17.5
+            ]
+        ],
+    ],
+]);
+
+echo $order;

--- a/official/docs/php/v5/orders/one-call-buy.php
+++ b/official/docs/php/v5/orders/one-call-buy.php
@@ -1,0 +1,25 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$order = \EasyPost\Order::create([
+    'carrier_accounts' => 'ca_...',
+    'service' => 'NextDayAir',
+    'to_address' => ['id' => 'adr_...'],
+    'from_address' => ['id' => 'adr_...'],
+    'shipments' => [
+        [
+            'parcel' => [
+                'weight' => 10.2
+            ]
+        ],
+        [
+            'parcel' => [
+                'predefined_package' => 'FedExBox',
+                'weight' => 17.5
+            ]
+        ],
+    ],
+]);
+
+echo $order;

--- a/official/docs/php/v5/orders/retrieve.php
+++ b/official/docs/php/v5/orders/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$order = \EasyPost\Order::retrieve('order_...');
+
+echo $order;

--- a/official/docs/php/v5/parcels/create.php
+++ b/official/docs/php/v5/parcels/create.php
@@ -1,0 +1,12 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$parcel = \EasyPost\Parcel::create([
+    'length' => 20.2,
+    'width' => 10.9,
+    'height' => 5,
+    'weight' => 65.9
+]);
+
+echo $parcel;

--- a/official/docs/php/v5/parcels/retrieve.php
+++ b/official/docs/php/v5/parcels/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$parcel = \EasyPost\Parcel::retrieve('prcl_...');
+
+echo $parcel;

--- a/official/docs/php/v5/pickups/buy.php
+++ b/official/docs/php/v5/pickups/buy.php
@@ -1,0 +1,12 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$pickup = \EasyPost\Pickup::retrieve('pickup_...');
+
+$pickup->buy([
+    'carrier' => 'UPS',
+    'service' => 'Same-day Pickup'
+]);
+
+echo $pickup;

--- a/official/docs/php/v5/pickups/cancel.php
+++ b/official/docs/php/v5/pickups/cancel.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$pickup = \EasyPost\Pickup::retrieve('pickup_...');
+
+$pickup->cancel();
+
+echo $pickup;

--- a/official/docs/php/v5/pickups/create.php
+++ b/official/docs/php/v5/pickups/create.php
@@ -1,0 +1,15 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$pickup = \EasyPost\Pickup::create([
+    'address' => ['id' => 'adr_...'],
+    'shipment' => ['id' => 'shp_...'],
+    'reference' => 'my-first-pickup',
+    'min_datetime' => date('2022-10-01 10:30:00'),
+    'max_datetime' => date('2022-10-02 10:30:00'),
+    'is_account_address' => false,
+    'instructions' => 'Special pickup instructions'
+]);
+
+echo $pickup;

--- a/official/docs/php/v5/pickups/retrieve.php
+++ b/official/docs/php/v5/pickups/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$pickup = \EasyPost\Pickup::retrieve('pickup_...');
+
+echo $pickup;

--- a/official/docs/php/v5/rates/regenerate.php
+++ b/official/docs/php/v5/rates/regenerate.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+$shipment->regenerate_rates();
+
+echo $shipment;

--- a/official/docs/php/v5/rates/retrieve.php
+++ b/official/docs/php/v5/rates/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$rate = \EasyPost\Rate::retrieve('rate...');
+
+echo $rate;

--- a/official/docs/php/v5/referral-customers/create.php
+++ b/official/docs/php/v5/referral-customers/create.php
@@ -1,0 +1,11 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$referralUser = Referral::create([
+  'name' => 'Test Referral',
+  'email' => 'test@test.com',
+  'phone' => '8888888888'
+]);
+
+echo $referralUser;

--- a/official/docs/php/v5/referral-customers/list.php
+++ b/official/docs/php/v5/referral-customers/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$referralUsers = Referral::all([
+  'page_size' => 5,
+]);
+
+echo $referralUsers;

--- a/official/docs/php/v5/referral-customers/update.php
+++ b/official/docs/php/v5/referral-customers/update.php
@@ -1,0 +1,5 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+Referral::update_email('new_email@example.com', 'user_...');

--- a/official/docs/php/v5/refunds/create.php
+++ b/official/docs/php/v5/refunds/create.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+$shipment->refund();
+
+echo $shipment;

--- a/official/docs/php/v5/reports/create.php
+++ b/official/docs/php/v5/reports/create.php
@@ -1,0 +1,10 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$report = \EasyPost\Report::create([
+    'start_date' => '2022-10-01',
+    'end_date' => '2022-10-31',
+]);
+
+echo $report;

--- a/official/docs/php/v5/reports/list.php
+++ b/official/docs/php/v5/reports/list.php
@@ -1,0 +1,11 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$reports = \EasyPost\Report::all([
+    // Replace `payment_log` with any of the report types listed above
+    'type' => 'payment_log',
+    'page_size' => 5,
+]);
+
+echo $reports;

--- a/official/docs/php/v5/reports/retrieve.php
+++ b/official/docs/php/v5/reports/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$report = \EasyPost\Report::retrieve('<REPORT_ID>');
+
+echo $report;

--- a/official/docs/php/v5/returns/create.php
+++ b/official/docs/php/v5/returns/create.php
@@ -1,0 +1,36 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::create([
+    'to_address' => [
+        'name' => 'Dr. Steve Brule',
+        'street1' => '179 N Harbor Dr',
+        'city' => 'Redondo Beach',
+        'state' => 'CA',
+        'zip' => '90277',
+        'country' => 'US',
+        'phone' => '3331114444',
+        'email' => 'dr_steve_brule@gmail.com'
+    ],
+    'from_address' => [
+        'name' => 'EasyPost',
+        'street1' => '417 Montgomery Street',
+        'street2' => '5th Floor',
+        'city' => 'San Francisco',
+        'state' => 'CA',
+        'zip' => '94104',
+        'country' => 'US',
+        'phone' => '3331114444',
+        'email' => 'support@easypost.com'
+    ],
+    'parcel' => [
+        'length' => 20.2,
+        'width' => 10.9,
+        'height' => 5,
+        'weight' => 65.9
+    ],
+    'is_return' => true
+]);
+
+echo $shipment;

--- a/official/docs/php/v5/scan-form/create.php
+++ b/official/docs/php/v5/scan-form/create.php
@@ -1,0 +1,12 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$scanForm = \EasyPost\ScanForm::create([
+    'shipments' => [
+        ['id' => 'shp_...'],
+        ['id' => 'shp_...'],
+    ]
+]);
+
+echo $scanForm;

--- a/official/docs/php/v5/scan-form/list.php
+++ b/official/docs/php/v5/scan-form/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$scanForms = \EasyPost\ScanForm::all([
+    'page_size' => 5
+]);
+
+echo $scanForms;

--- a/official/docs/php/v5/scan-form/retrieve.php
+++ b/official/docs/php/v5/scan-form/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$scanForm = \EasyPost\ScanForm::retrieve('sf_...');
+
+echo $scanForm;

--- a/official/docs/php/v5/shipments/buy.php
+++ b/official/docs/php/v5/shipments/buy.php
@@ -1,0 +1,12 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+$shipment->buy([
+    'rate'      => $shipment->lowest_rate(),
+    'insurance' => 249.99
+]);
+
+echo $shipment;

--- a/official/docs/php/v5/shipments/create.php
+++ b/official/docs/php/v5/shipments/create.php
@@ -1,0 +1,35 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::create([
+    'to_address' => [
+        'name' => 'Dr. Steve Brule',
+        'street1' => '179 N Harbor Dr',
+        'city' => 'Redondo Beach',
+        'state' => 'CA',
+        'zip' => '90277',
+        'country' => 'US',
+        'phone' => '3331114444',
+        'email' => 'dr_steve_brule@gmail.com'
+    ],
+    'from_address' => [
+        'name' => 'EasyPost',
+        'street1' => '417 Montgomery Street',
+        'street2' => '5th Floor',
+        'city' => 'San Francisco',
+        'state' => 'CA',
+        'zip' => '94104',
+        'country' => 'US',
+        'phone' => '3331114444',
+        'email' => 'support@easypost.com'
+    ],
+    'parcel' => [
+        'length' => 20.2,
+        'width' => 10.9,
+        'height' => 5,
+        'weight' => 65.9
+    ]
+]);
+
+echo $shipment;

--- a/official/docs/php/v5/shipments/label.php
+++ b/official/docs/php/v5/shipments/label.php
@@ -1,0 +1,10 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+$shipment->label([
+    'file_format' => 'ZPL'
+]);
+
+echo $shipment;

--- a/official/docs/php/v5/shipments/list.php
+++ b/official/docs/php/v5/shipments/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipments = \EasyPost\Shipment::all([
+    'page_size' => 5,
+]);
+
+echo $shipments;

--- a/official/docs/php/v5/shipments/one-call-buy.php
+++ b/official/docs/php/v5/shipments/one-call-buy.php
@@ -1,0 +1,37 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::create([
+    'carrier_accounts' => ['ca_...'],
+    'service' => 'NextDayAir',
+    'to_address' => [
+        'name' => 'Dr. Steve Brule',
+        'street1' => '179 N Harbor Dr',
+        'city' => 'Redondo Beach',
+        'state' => 'CA',
+        'zip' => '90277',
+        'country' => 'US',
+        'phone' => '3331114444',
+        'email' => 'dr_steve_brule@gmail.com'
+    ],
+    'from_address' => [
+        'name' => 'EasyPost',
+        'street1' => '417 Montgomery Street',
+        'street2' => '5th Floor',
+        'city' => 'San Francisco',
+        'state' => 'CA',
+        'zip' => '94104',
+        'country' => 'US',
+        'phone' => '3331114444',
+        'email' => 'support@easypost.com'
+    ],
+    'parcel' => [
+        'length' => 20.2,
+        'width' => 10.9,
+        'height' => 5,
+        'weight' => 65.9
+    ]
+]);
+
+echo $shipment;

--- a/official/docs/php/v5/shipments/retrieve.php
+++ b/official/docs/php/v5/shipments/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+echo $shipment;

--- a/official/docs/php/v5/shipping-insurance/insure.php
+++ b/official/docs/php/v5/shipping-insurance/insure.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+$shipment->insure(['amount' => 100]);
+
+echo $shipment;

--- a/official/docs/php/v5/smartrate/retrieve-time-in-transit-statistics.php
+++ b/official/docs/php/v5/smartrate/retrieve-time-in-transit-statistics.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::retrieve('shp_...');
+
+$shipment->get_smartrates();
+
+echo $shipment;

--- a/official/docs/php/v5/tax-identifiers/create.php
+++ b/official/docs/php/v5/tax-identifiers/create.php
@@ -1,0 +1,42 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$shipment = \EasyPost\Shipment::create([
+    'to_address' => [
+        'name' => 'Dr. Steve Brule',
+        'street1' => '179 N Harbor Dr',
+        'city' => 'Redondo Beach',
+        'state' => 'CA',
+        'zip' => '90277',
+        'country' => 'US',
+        'phone' => '3331114444',
+        'email' => 'dr_steve_brule@gmail.com'
+    ],
+    'from_address' => [
+        'name' => 'EasyPost',
+        'street1' => '417 Montgomery Street',
+        'street2' => '5th Floor',
+        'city' => 'San Francisco',
+        'state' => 'CA',
+        'zip' => '94104',
+        'country' => 'US',
+        'phone' => '3331114444',
+        'email' => 'support@easypost.com'
+    ],
+    'parcel' => [
+        'length' => 20.2,
+        'width' => 10.9,
+        'height' => 5,
+        'weight' => 65.9
+    ],
+    'customs_info' => ['id' => 'cstinfo_...'],
+    'tax_identifiers' => [[
+        'entity' => 'SENDER',
+        'tax_id' => 'GB123456789',
+        'tax_id_type' => 'IOSS',
+        'issuing_country' => 'GB',
+    ]]
+]);
+
+echo $shipment;

--- a/official/docs/php/v5/trackers/create.php
+++ b/official/docs/php/v5/trackers/create.php
@@ -1,0 +1,10 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$tracker = \EasyPost\Tracker::create([
+    'tracking_code' => 'EZ1000000001',
+    'carrier' => 'USPS'
+]);
+
+echo $tracker;

--- a/official/docs/php/v5/trackers/list.php
+++ b/official/docs/php/v5/trackers/list.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$trackers = \EasyPost\Tracker::all([
+    'page_size' => 5,
+]);
+
+echo $trackers;

--- a/official/docs/php/v5/trackers/retrieve.php
+++ b/official/docs/php/v5/trackers/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$tracker = \EasyPost\Tracker::retrieve('trk_...');
+
+echo $tracker;

--- a/official/docs/php/v5/users/retrieve.php
+++ b/official/docs/php/v5/users/retrieve.php
@@ -1,0 +1,11 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+// Retrieve the authenticated user
+$user = \EasyPost\User::retrieve_me();
+
+// Retrieve a child user
+$user = \EasyPost\User::retrieve('user_...');
+
+echo $user;

--- a/official/docs/php/v5/users/update.php
+++ b/official/docs/php/v5/users/update.php
@@ -1,0 +1,11 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$user = \EasyPost\User::retrieve_me();
+
+$user->recharge_threshold = '50.00';
+
+$user->save();
+
+echo $user;

--- a/official/docs/php/v5/webhooks/create.php
+++ b/official/docs/php/v5/webhooks/create.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$webhook = \EasyPost\Webhook::create(['url' => 'example.com']);
+
+echo $webhook;

--- a/official/docs/php/v5/webhooks/delete.php
+++ b/official/docs/php/v5/webhooks/delete.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$webhook = \EasyPost\Webhook::retrieve('hook_...');
+
+$webhook->delete();
+
+echo $webhook;

--- a/official/docs/php/v5/webhooks/list.php
+++ b/official/docs/php/v5/webhooks/list.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$webhooks = \EasyPost\Webhook::all();
+
+echo $webhooks;

--- a/official/docs/php/v5/webhooks/retrieve.php
+++ b/official/docs/php/v5/webhooks/retrieve.php
@@ -1,0 +1,7 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$webhook = \EasyPost\Webhook::retrieve('hook_...');
+
+echo $webhook;

--- a/official/docs/php/v5/webhooks/update.php
+++ b/official/docs/php/v5/webhooks/update.php
@@ -1,0 +1,9 @@
+<?php
+
+\EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
+
+$webhook = \EasyPost\Webhook::retrieve('hook_...');
+
+$webhook->update();
+
+echo $webhook;


### PR DESCRIPTION
Adds the new set of v6 PHP docs to the repo. Changes include the new EasyPostClient, camelCase function names, and proper return values since nothing is instance based anymore.

The `v5` directory was copied over from the old set, no changes made.