### PR TITLE
fix: carrierAccount docs and accidental PHP vars

### DIFF
--- a/official/docs/csharp/current/carrier-accounts/create.cs
+++ b/official/docs/csharp/current/carrier-accounts/create.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using EasyPost;
 using EasyPost.Models.API;
+using Newtonsoft.Json;
 
 namespace EasyPostExamples
 {
@@ -17,25 +17,24 @@ namespace EasyPostExamples
 
             CarrierAccount carrierAccount = await client.CarrierAccount.Create(new Dictionary<string, object>()
             {
-                { "type", "UpsAccount" },
-                { "description", "NY Location UPS Account" },
-                { "reference", "my-reference" },
+                { "type", "DhlEcsAccount" },
+                { "description", "CA Location DHL eCommerce Solutions Account" },
                 {
                     "credentials", new Dictionary<string, object>
                     {
-                        { "account_number", "A1A1A1" },
-                        { "user_id", "USERID" },
-                        { "password", "PASSWORD" },
-                        { "access_license_number", "ALN" }
+                        { "client_id", "123456" },
+                        { "client_secret", "123abc" },
+                        { "distribution_center", "USLAX1" },
+                        { "pickup_id", "123456" }
                     }
                 },
                 {
                     "test_credentials", new Dictionary<string, object>
                     {
-                        { "account_number", "A1A1A1" },
-                        { "user_id", "USERID" },
-                        { "password", "PASSWORD" },
-                        { "access_license_number", "ALN" }
+                        { "client_id", "123456" },
+                        { "client_secret", "123abc" },
+                        { "distribution_center", "USLAX1" },
+                        { "pickup_id", "123456" }
                     }
                 },
             });

--- a/official/docs/csharp/current/carrier-accounts/update.cs
+++ b/official/docs/csharp/current/carrier-accounts/update.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using EasyPost;
 using EasyPost.Models.API;
+using Newtonsoft.Json;
 
 namespace EasyPostExamples
 {
@@ -19,12 +19,13 @@ namespace EasyPostExamples
 
             await carrierAccount.Update(new Dictionary<string, object>()
             {
-                { "description", "FL Location UPS Account" },
-                { "credentials", new Dictionary<string, object>()
+                { "description", "FL Location DHL eCommerce Solutions Account" },
                 {
-                    { "account_number", "B2B2B2" },
-                }
-            },
+                    "credentials", new Dictionary<string, object>()
+                    {
+                        { "pickup_id", "abc123" },
+                    }
+                },
             });
 
             Console.WriteLine(JsonConvert.SerializeObject(carrierAccount, Formatting.Indented));

--- a/official/docs/csharp/v3/carrier_accounts/create-carrier-account.cs
+++ b/official/docs/csharp/v3/carrier_accounts/create-carrier-account.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using EasyPost;
+using Newtonsoft.Json;
 
 namespace EasyPostExamples
 {
@@ -16,25 +16,24 @@ namespace EasyPostExamples
 
             CarrierAccount carrierAccount = await CarrierAccount.Create(new Dictionary<string, object>()
             {
-                { "type", "UpsAccount" },
-                { "description", "NY Location UPS Account" },
-                { "reference", "my-reference" },
+                { "type", "DhlEcsAccount" },
+                { "description", "CA Location DHL eCommerce Solutions Account" },
                 {
                     "credentials", new Dictionary<string, object>
                     {
-                        { "account_number", "A1A1A1" },
-                        { "user_id", "USERID" },
-                        { "password", "PASSWORD" },
-                        { "access_license_number", "ALN" }
+                        { "client_id", "123456" },
+                        { "client_secret", "123abc" },
+                        { "distribution_center", "USLAX1" },
+                        { "pickup_id", "123456" }
                     }
                 },
                 {
                     "test_credentials", new Dictionary<string, object>
                     {
-                        { "account_number", "A1A1A1" },
-                        { "user_id", "USERID" },
-                        { "password", "PASSWORD" },
-                        { "access_license_number", "ALN" }
+                        { "client_id", "123456" },
+                        { "client_secret", "123abc" },
+                        { "distribution_center", "USLAX1" },
+                        { "pickup_id", "123456" }
                     }
                 },
             });

--- a/official/docs/csharp/v3/carrier_accounts/update-carrier-account.cs
+++ b/official/docs/csharp/v3/carrier_accounts/update-carrier-account.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using EasyPost;
+using Newtonsoft.Json;
 
 namespace EasyPostExamples
 {
@@ -18,14 +18,13 @@ namespace EasyPostExamples
 
             await carrierAccount.Update(new Dictionary<string, object>()
             {
-                { "description", "FL Location UPS Account" }
+                { "description", "FL Location DHL eCommerce Solutions Account" },
                 {
-                "credentials",
-                new Dictionary<string, object>()
-                {
-                    { "account_number", "B2B2B2" },
-                }
-            },
+                    "credentials", new Dictionary<string, object>()
+                    {
+                        { "pickup_id", "abc123" },
+                    }
+                },
             });
 
             Console.WriteLine(JsonConvert.SerializeObject(carrierAccount, Formatting.Indented));

--- a/official/docs/curl/current/carrier-accounts/create.sh
+++ b/official/docs/curl/current/carrier-accounts/create.sh
@@ -3,20 +3,20 @@ curl -X POST https://api.easypost.com/v2/carrier_accounts \
   -H 'Content-Type: application/json' \
   -d '{
     "carrier_account": {
-      "type": "UpsAccount",
-      "description": "NY Location UPS Account",
+      "type": "DhlEcsAccount",
+      "description": "CA Location DHL eCommerce Solutions Account",
       "reference": "my-reference",
       "credentials": {
-        "account_number": "A1A1A1",
-        "user_id": "USERID",
-        "password": "PASSWORD",
-        "access_license_number": "ALN"
+        "client_id": "123456",
+        "client_secret": "123abc",
+        "distribution_center": "USLAX1",
+        "pickup_id": "123456"
       },
       "test_credentials": {
-        "account_number": "A1A1A1",
-        "user_id": "USERID",
-        "password": "PASSWORD",
-        "access_license_number": "ALN"
+        "client_id": "123456",
+        "client_secret": "123abc",
+        "distribution_center": "USLAX1",
+        "pickup_id": "123456"
       }
     }
   }'

--- a/official/docs/curl/current/carrier-accounts/update.sh
+++ b/official/docs/curl/current/carrier-accounts/update.sh
@@ -3,9 +3,9 @@ curl -X PATCH https://api.easypost.com/v2/carrier_accounts/ca_... \
   -H 'Content-Type: application/json' \
   -d '{
     "carrier_account": {
-      "description": "FL Location UPS Account",
+      "description": "FL Location DHL eCommerce Solutions Account",
       "credentials": {
-        "account_number": "B2B2B2",
+        "pickup_id": "abc123",
       }
     }
   }'

--- a/official/docs/golang/current/carrier-accounts/update.go
+++ b/official/docs/golang/current/carrier-accounts/update.go
@@ -15,7 +15,8 @@ func main() {
 
 	carrierAccount, _ = client.UpdateCarrierAccount(
 		&easypost.CarrierAccount{
-			ID: carrierAccount.ID,
+			ID:          carrierAccount.ID,
+			Description: "FL Location DHL eCommerce Solutions Account",
 			Credentials: map[string]string{
 				"pickup_id": "abc123",
 			},

--- a/official/docs/java/current/carrier-accounts/update.java
+++ b/official/docs/java/current/carrier-accounts/update.java
@@ -14,6 +14,7 @@ public class Update {
         credentials.put("pickup_id", "abc123");
 
         HashMap<String, Object> params = new HashMap<String, Object>();
+        params.put("description", "FL Location DHL eCommerce Solutions Account");
         params.put("credentials", credentials);
 
         CarrierAccount carrierAccount = client.carrierAccount.update("ca_...", params);

--- a/official/docs/java/v5/carrier-accounts/update.java
+++ b/official/docs/java/v5/carrier-accounts/update.java
@@ -16,6 +16,7 @@ public class Update {
         credentials.put("pickup_id", "abc123");
 
         HashMap<String, Object> params = new HashMap<String, Object>();
+        params.put("description", "FL Location DHL eCommerce Solutions Account");
         params.put("credentials", credentials);
 
         carrierAccount.update(params);

--- a/official/docs/node/current/carrier-accounts/update.js
+++ b/official/docs/node/current/carrier-accounts/update.js
@@ -3,6 +3,7 @@ const Easypost = require('@easypost/api');
 const api = new Easypost(process.env.EASYPOST_API_KEY);
 
 api.CarrierAccount.retrieve('ca_...').then((carrierAccount) => {
+  carrierAccount.description = 'FL Location DHL eCommerce Solutions Account';
   carrierAccount.credentials.pickup_id = 'abc123';
   carrierAccount.save().then(console.log);
 });

--- a/official/docs/php/current/addresses/verify.php
+++ b/official/docs/php/current/addresses/verify.php
@@ -13,6 +13,6 @@ $address = $client->address->create([
     'phone'   => '415-123-4567'
 ]);
 
-$verifiedAddress = $client->$address->verify($address->id);
+$verifiedAddress = $client->address->verify($address->id);
 
 echo $verifiedAddress;

--- a/official/docs/php/current/api-keys/retrieve.php
+++ b/official/docs/php/current/api-keys/retrieve.php
@@ -7,6 +7,6 @@ $apiKeys = $client->user->allApiKeys();
 
 // Retrieve API keys for a child user
 $childUser = $client->user->retrieve('user_...');
-$apiKeys = $client->$user->apiKeys($childUser->id);
+$apiKeys = $client->user->apiKeys($childUser->id);
 
 echo $apiKeys;

--- a/official/docs/php/current/batches/add-shipments.php
+++ b/official/docs/php/current/batches/add-shipments.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $batch = $client->batch->retrieve('batch_...');
 
-$batchWithShipments = $client->$batch->addShipments(
+$batchWithShipments = $client->batch->addShipments(
     $batch->id,
     [
         'shipments' => [

--- a/official/docs/php/current/batches/buy.php
+++ b/official/docs/php/current/batches/buy.php
@@ -4,6 +4,6 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $batch = $client->batch->retrieve('batch_...');
 
-$boughtBatch = $client->$batch->buy($batch->id);
+$boughtBatch = $client->batch->buy($batch->id);
 
 echo $boughtBatch;

--- a/official/docs/php/current/batches/label.php
+++ b/official/docs/php/current/batches/label.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $batch = $client->batch->retrieve('batch_...');
 
-$batchWithLabel = $client->$batch->label(
+$batchWithLabel = $client->batch->label(
     $batch->id,
     ['file_format' => 'PDF']
 );

--- a/official/docs/php/current/batches/remove-shipments.php
+++ b/official/docs/php/current/batches/remove-shipments.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $batch = $client->batch->retrieve('batch_...');
 
-$batchWithoutShipments = $client->$batch->removeShipments(
+$batchWithoutShipments = $client->batch->removeShipments(
     $shipment->id,
     [
         'shipments' => [

--- a/official/docs/php/current/batches/scan-forms.php
+++ b/official/docs/php/current/batches/scan-forms.php
@@ -4,6 +4,6 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $batch = $client->batch->retrieve('batch_...');
 
-$batchWithScanForm = $client->$batch->createScanForm($batch->id);
+$batchWithScanForm = $client->batch->createScanForm($batch->id);
 
 echo $batchWithScanForm;

--- a/official/docs/php/current/brand/update.php
+++ b/official/docs/php/current/brand/update.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $user = $client->user->retrieveMe();
 
-$brand = $client->$user->updateBrand(
+$brand = $client->user->updateBrand(
     $user->id,
     ['color' => '#303F9F']
 );

--- a/official/docs/php/current/carbon-offset/buy.php
+++ b/official/docs/php/current/carbon-offset/buy.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $shipment = $client->shipment->retrieve('shp_...');
 
-$boughtShipment = $client->$shipment->buy(
+$boughtShipment = $client->shipment->buy(
     $shipment->id,
     [
         'rate'      => $shipment->lowestRate(),

--- a/official/docs/php/current/carrier-accounts/delete.php
+++ b/official/docs/php/current/carrier-accounts/delete.php
@@ -4,4 +4,4 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $carrierAccount = $client->carrierAccount->retrieve('ca_...');
 
-$client->$carrierAccount->delete($carrierAccount->id);
+$client->carrierAccount->delete($carrierAccount->id);

--- a/official/docs/php/current/carrier-accounts/update.php
+++ b/official/docs/php/current/carrier-accounts/update.php
@@ -4,9 +4,14 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $carrierAccount = $client->carrierAccount->retrieve('ca_...');
 
-$updatedCarrierAccount = $client->$carrierAccount->update(
+$updatedCarrierAccount = $client->carrierAccount->update(
     $carrierAccount->id,
-    ['pickup_id' => 'abc123']
+    [
+        'description' => 'FL Location DHL eCommerce Solutions Account',
+        'credentials' => [
+            'pickup_id' => 'abc123',
+        ]
+    ]
 );
 
 echo $updatedCarrierAccount;

--- a/official/docs/php/current/child-users/delete.php
+++ b/official/docs/php/current/child-users/delete.php
@@ -4,4 +4,4 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $user = $client->user->retrieve('user_...');
 
-$client->$user->delete($user->id);
+$client->user->delete($user->id);

--- a/official/docs/php/current/endshipper/buy.php
+++ b/official/docs/php/current/endshipper/buy.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $shipment = $client->shipment->retrieve('shp_...');
 
-$boughtShipment = $client->$shipment->buy(
+$boughtShipment = $client->shipment->buy(
     $shipment->id,
     [
         'rate'      => $shipment->lowestRate(),

--- a/official/docs/php/current/endshipper/update.php
+++ b/official/docs/php/current/endshipper/update.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $endshipper = $client->endShipper->retrieve('es_...');
 
-$updatedEndShipper = $client->$endShipper->update(
+$updatedEndShipper = $client->endShipper->update(
     $endShipper->id,
     [
         'name' => 'NEW NAME',

--- a/official/docs/php/current/forms/create.php
+++ b/official/docs/php/current/forms/create.php
@@ -18,6 +18,6 @@ $formOptions = [
     ],
 ];
 
-$shipmentWithForm = $client->$shipment->generateForm($shipment->id, $formType, $formOptions);
+$shipmentWithForm = $client->shipment->generateForm($shipment->id, $formType, $formOptions);
 
 echo $shipmentWithForm;

--- a/official/docs/php/current/orders/buy.php
+++ b/official/docs/php/current/orders/buy.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $order = $client->order->retrieve('order_...');
 
-$boughtOrder = $client->$order->buy(
+$boughtOrder = $client->order->buy(
     $shipment->id,
     [
         'carrier' => 'FedEx',

--- a/official/docs/php/current/pickups/buy.php
+++ b/official/docs/php/current/pickups/buy.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $pickup = $client->pickup->retrieve('pickup_...');
 
-$boughtPickup = $client->$pickup->buy(
+$boughtPickup = $client->pickup->buy(
     $pickup->id,
     [
         'carrier' => 'UPS',

--- a/official/docs/php/current/pickups/cancel.php
+++ b/official/docs/php/current/pickups/cancel.php
@@ -4,6 +4,6 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $pickup = $client->pickup->retrieve('pickup_...');
 
-$cancelledPickup = $client->$pickup->cancel($pickup->id);
+$cancelledPickup = $client->pickup->cancel($pickup->id);
 
 echo $cancelledPickup;

--- a/official/docs/php/current/rates/regenerate.php
+++ b/official/docs/php/current/rates/regenerate.php
@@ -4,6 +4,6 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $shipment = $client->shipment->retrieve('shp_...');
 
-$shipmentWithRegeneratedrates = $client->$shipment->regenerateRates($shipment->id);
+$shipmentWithRegeneratedrates = $client->shipment->regenerateRates($shipment->id);
 
 echo $shipmentWithRegeneratedrates;

--- a/official/docs/php/current/shipments/buy.php
+++ b/official/docs/php/current/shipments/buy.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $shipment = $client->shipment->retrieve('shp_...');
 
-$boughtShipment = $client->$shipment->buy(
+$boughtShipment = $client->shipment->buy(
     $shipment->id,
     [
         'rate'      => $shipment->lowestRate(),

--- a/official/docs/php/current/shipments/label.php
+++ b/official/docs/php/current/shipments/label.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $shipment = $client->shipment->retrieve('shp_...');
 
-$shipmentWithLabel = $client->$shipment->label(
+$shipmentWithLabel = $client->shipment->label(
     $shipment->id,
     ['file_format' => 'ZPL']
 );

--- a/official/docs/php/current/shipping-insurance/insure.php
+++ b/official/docs/php/current/shipping-insurance/insure.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $shipment = $client->shipment->retrieve('shp_...');
 
-$shipmentWithInsurance = $client->$shipment->insure(
+$shipmentWithInsurance = $client->shipment->insure(
     $shipment->id,
     ['amount' => 100]
 );

--- a/official/docs/php/current/shipping-refund/refund.php
+++ b/official/docs/php/current/shipping-refund/refund.php
@@ -4,6 +4,6 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $shipment = $client->shipment->retrieve('shp_...');
 
-$refundedShipment = $client->$shipment->refund($shipment->id);
+$refundedShipment = $client->shipment->refund($shipment->id);
 
 echo $refundedShipment;

--- a/official/docs/php/current/smartrate/retrieve-time-in-transit-statistics.php
+++ b/official/docs/php/current/smartrate/retrieve-time-in-transit-statistics.php
@@ -4,6 +4,6 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $shipment = $client->shipment->retrieve('shp_...');
 
-$smartRates = $client->$shipment->getSmartrates();
+$smartRates = $client->shipment->getSmartrates();
 
 echo $smartRates;

--- a/official/docs/php/current/users/update.php
+++ b/official/docs/php/current/users/update.php
@@ -4,7 +4,7 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $user = $client->user->retrieveMe();
 
-$updatedUser = $client->$user->update(
+$updatedUser = $client->user->update(
     $user->id,
     ['recharge_threshold' => '50.00']
 );

--- a/official/docs/php/current/webhooks/delete.php
+++ b/official/docs/php/current/webhooks/delete.php
@@ -4,4 +4,4 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $webhook = $client->webhook->retrieve('hook_...');
 
-$client->$webhook->delete($webhook->id);
+$client->webhook->delete($webhook->id);

--- a/official/docs/php/current/webhooks/update.php
+++ b/official/docs/php/current/webhooks/update.php
@@ -4,6 +4,6 @@ $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 $webhook = $client->webhook->retrieve('hook_...');
 
-$updatedWebhook = $client->$webhook->update();
+$updatedWebhook = $client->webhook->update();
 
 echo $updatedWebhook;

--- a/official/docs/php/v5/carrier-accounts/update.php
+++ b/official/docs/php/v5/carrier-accounts/update.php
@@ -2,6 +2,9 @@
 
 \EasyPost\EasyPost::setApiKey($_ENV['EASYPOST_API_KEY']);
 
+$carrierAccount = \EasyPost\CarrierAccount::retrieve('ca_...');
+
+$carrierAccount->description = 'FL Location DHL eCommerce Solutions Account';
 $carrierAccount->credentials['pickup_id'] = 'abc123';
 
 $carrierAccount->save();

--- a/official/docs/python/current/carrier-accounts/update.py
+++ b/official/docs/python/current/carrier-accounts/update.py
@@ -7,6 +7,7 @@ easypost.api_key = os.getenv("EASYPOST_API_KEY")
 
 carrier_account = easypost.CarrierAccount.retrieve("ca_...")
 
+carrier_account.description = "FL Location DHL eCommerce Solutions Account"
 carrier_account.credentials["pickup_id"] = "abc123"
 carrier_account.save()
 

--- a/official/docs/ruby/current/carrier-accounts/update.rb
+++ b/official/docs/ruby/current/carrier-accounts/update.rb
@@ -4,7 +4,7 @@ EasyPost.api_key = ENV['EASYPOST_API_KEY']
 
 carrier_account = EasyPost::CarrierAccount.retrieve('ca_...')
 
-carrier_account.description = 'FL Location UPS Account'
+carrier_account.description = 'FL Location DHL eCommerce Solutions Account'
 carrier_account.credentials['pickup_id'] = 'abc123'
 
 carrier_account.save


### PR DESCRIPTION
This PR fixes two things:

1. Our very incorrect CarrierAccount docs that were all over the place, incorrect, missing details, or didn't match each other
2. There were some accidental dollar signs left over from the v6 PHP docs in service names that shouldn't be there
