### PR TITLE
fix: php carrier account update v5 example

### DIFF
--- a/official/docs/php/v5/carrier-accounts/update.php
+++ b/official/docs/php/v5/carrier-accounts/update.php
@@ -5,7 +5,7 @@
 $carrierAccount = \EasyPost\CarrierAccount::retrieve('ca_...');
 
 $carrierAccount->description = 'FL Location DHL eCommerce Solutions Account';
-$carrierAccount->credentials['pickup_id'] = 'abc123';
+$carrierAccount->credentials = ['pickup_id' => 'abc123'];
 
 $carrierAccount->save();
 


### PR DESCRIPTION
Corrects the syntax of the PHP update carrier account example for v5