### PR TITLE
feat: adds retrieve-estimated-delivery-date placeholders

### DIFF
--- a/official/docs/csharp/current/smartrate/retrieve-estimated-delivery-date.cs
+++ b/official/docs/csharp/current/smartrate/retrieve-estimated-delivery-date.cs
@@ -1,0 +1,1 @@
+// This feature is coming soon to this library; until then, you can use the cURL example or our Postman Collection

--- a/official/docs/curl/current/smartrate/retrieve-estimated-delivery-date.sh
+++ b/official/docs/curl/current/smartrate/retrieve-estimated-delivery-date.sh
@@ -1,0 +1,2 @@
+curl -X GET https://api.easypost.com/v2/shipments/shp_.../smartrate/delivery_date?planned_ship_date=yyyy-mm-dd \
+  -u "$EASYPOST_API_KEY":

--- a/official/docs/golang/current/smartrate/retrieve-estimated-delivery-date.go
+++ b/official/docs/golang/current/smartrate/retrieve-estimated-delivery-date.go
@@ -1,0 +1,1 @@
+// This feature is coming soon to this library; until then, you can use the cURL example or our Postman Collection

--- a/official/docs/java/current/smartrate/retrieve-estimated-delivery-date.java
+++ b/official/docs/java/current/smartrate/retrieve-estimated-delivery-date.java
@@ -1,0 +1,2 @@
+// This feature is coming soon to this library; until then, you can use the cURL
+// example or our Postman Collection

--- a/official/docs/node/current/smartrate/retrieve-estimated-delivery-date.js
+++ b/official/docs/node/current/smartrate/retrieve-estimated-delivery-date.js
@@ -1,0 +1,1 @@
+// This feature is coming soon to this library; until then, you can use the cURL example or our Postman Collection

--- a/official/docs/php/current/smartrate/retrieve-estimated-delivery-date.php
+++ b/official/docs/php/current/smartrate/retrieve-estimated-delivery-date.php
@@ -1,0 +1,3 @@
+<?php
+
+// This feature is coming soon to this library; until then, you can use the cURL example or our Postman Collection

--- a/official/docs/python/current/smartrate/retrieve-estimated-delivery-date.py
+++ b/official/docs/python/current/smartrate/retrieve-estimated-delivery-date.py
@@ -1,0 +1,1 @@
+# This feature is coming soon to this library; until then, you can use the cURL example or our Postman Collection

--- a/official/docs/responses/smartrate/smartrate-retrieve-estimated-delivery-date.json
+++ b/official/docs/responses/smartrate/smartrate-retrieve-estimated-delivery-date.json
@@ -1,0 +1,40 @@
+{
+  "rates": [
+    {
+      "easypost_time_in_transit_data": {
+        "days_in_transit": {
+          "percentile_50": 2,
+          "percentile_75": 2,
+          "percentile_85": 2,
+          "percentile_90": 2,
+          "percentile_95": 2,
+          "percentile_97": 3,
+          "percentile_99": 4
+        },
+        "easypost_estimated_delivery_date": "2023-04-27",
+        "planned_ship_date": "2023-04-25"
+      },
+      "rate": {
+        "carrier": "USPS",
+        "carrier_account_id": "ca_4fcd9a658b494a979793bb899a40c5b5",
+        "created_at": "2023-04-24T20:17:20Z",
+        "currency": "USD",
+        "delivery_date": null,
+        "delivery_date_guaranteed": false,
+        "delivery_days": 2,
+        "est_delivery_days": 2,
+        "id": "rate_078538dd44654bc79c79163f4a5de5f4",
+        "list_currency": "USD",
+        "list_rate": 10.27,
+        "mode": "test",
+        "object": "Rate",
+        "rate": 9.15,
+        "retail_currency": "USD",
+        "retail_rate": 14.05,
+        "service": "Priority",
+        "shipment_id": "shp_3f16e63fcb614f38b405c417c57203f4",
+        "updated_at": "2023-04-24T20:17:20Z"
+      }
+    }
+  ]
+}

--- a/official/docs/ruby/current/smartrate/retrieve-estimated-delivery-date.rb
+++ b/official/docs/ruby/current/smartrate/retrieve-estimated-delivery-date.rb
@@ -1,0 +1,1 @@
+# This feature is coming soon to this library; until then, you can use the cURL example or our Postman Collection


### PR DESCRIPTION
Adds `retrieve-estimated-delivery-date` placeholders. Response and curl are here for now, other languages will be added in a follow-up PR once we've added them to each lib.
