### PR TITLE
remove unnecessary comma in curl for stateless rate

### DIFF
--- a/official/docs/curl/current/rates/retrieve-stateless.sh
+++ b/official/docs/curl/current/rates/retrieve-stateless.sh
@@ -11,7 +11,7 @@ $ curl -X POST "https://api.easypost.com/beta/rates" \
       "zip": "90277",
       "country": "US",
       "phone": "8573875756",
-      "email": "dr_steve_brule@gmail.com",
+      "email": "dr_steve_brule@gmail.com"
     },
     "from_address": {
       "name": "EasyPost",


### PR DESCRIPTION
Our API is throwing `Malformed request` because of the extra comma at the end of `email`