### PR TITLE
fix: remove unecessary newlines after imports for Python examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,9 +139,9 @@ format-php:
 ## format-python - formats Python files
 format-python:
 	$(PYTHON_VIRTUAL_BIN)/black official/docs/python/
-	$(PYTHON_VIRTUAL_BIN)/isort official/docs/python/
+	$(PYTHON_VIRTUAL_BIN)/isort official/docs/python/ --lines-after-imports -1 --no-sections
 	$(PYTHON_VIRTUAL_BIN)/black official/guides/
-	$(PYTHON_VIRTUAL_BIN)/isort official/guides/
+	$(PYTHON_VIRTUAL_BIN)/isort official/guides/ --lines-after-imports -1 --no-sections
 
 ## format-ruby - formats Ruby files
 format-ruby:
@@ -159,6 +159,6 @@ format-node-check:
 ## format-python-check - checks that Python files conform to the correct format
 format-python-check:
 	$(PYTHON_VIRTUAL_BIN)/black official/docs/python/ --check
-	$(PYTHON_VIRTUAL_BIN)/isort official/docs/python/ --check-only
+	$(PYTHON_VIRTUAL_BIN)/isort official/docs/python/ --lines-after-imports -1 --no-sections --check-only
 
 .PHONY: help install install-csharp install-go install-java install-node install-php install-python install-ruby install-shell lint lint-csharp lint-go lint-java lint-node lint-php lint-python lint-ruby lint-shell format format-csharp format-go format-java format-node format-php format-python format-ruby format-shell format-node-check format-python-check

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ lint-php:
 lint-python:
 	$(PYTHON_VIRTUAL_BIN)/flake8 official/docs/python/
 	$(PYTHON_VIRTUAL_BIN)/flake8 official/guides/
+	$(PYTHON_VIRTUAL_BIN)/flake8 official/landing_pages/
 
 ## lint-ruby - lints Ruby files
 lint-ruby:

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,8 @@ format-python:
 	$(PYTHON_VIRTUAL_BIN)/isort official/docs/python/ --lines-after-imports -1 --no-sections
 	$(PYTHON_VIRTUAL_BIN)/black official/guides/
 	$(PYTHON_VIRTUAL_BIN)/isort official/guides/ --lines-after-imports -1 --no-sections
+	$(PYTHON_VIRTUAL_BIN)/black official/landing_pages/
+	$(PYTHON_VIRTUAL_BIN)/isort official/landing_pages/ --lines-after-imports -1 --no-sections
 
 ## format-ruby - formats Ruby files
 format-ruby:
@@ -160,5 +162,9 @@ format-node-check:
 format-python-check:
 	$(PYTHON_VIRTUAL_BIN)/black official/docs/python/ --check
 	$(PYTHON_VIRTUAL_BIN)/isort official/docs/python/ --lines-after-imports -1 --no-sections --check-only
+	$(PYTHON_VIRTUAL_BIN)/black official/guides/ --check
+	$(PYTHON_VIRTUAL_BIN)/isort official/guides/ --lines-after-imports -1 --no-sections --check-only
+	$(PYTHON_VIRTUAL_BIN)/black official/landing_pages/ --check
+	$(PYTHON_VIRTUAL_BIN)/isort official/landing_pages/ --lines-after-imports -1 --no-sections --check-only
 
 .PHONY: help install install-csharp install-go install-java install-node install-php install-python install-ruby install-shell lint lint-csharp lint-go lint-java lint-node lint-php lint-python lint-ruby lint-shell format format-csharp format-go format-java format-node format-php format-python format-ruby format-shell format-node-check format-python-check

--- a/official/docs/python/current/addresses/create-and-verify.py
+++ b/official/docs/python/current/addresses/create-and-verify.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/addresses/create.py
+++ b/official/docs/python/current/addresses/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/addresses/list.py
+++ b/official/docs/python/current/addresses/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/addresses/retrieve.py
+++ b/official/docs/python/current/addresses/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/addresses/verify-failure.py
+++ b/official/docs/python/current/addresses/verify-failure.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/addresses/verify-param.py
+++ b/official/docs/python/current/addresses/verify-param.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/addresses/verify-strict-param.py
+++ b/official/docs/python/current/addresses/verify-strict-param.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/addresses/verify.py
+++ b/official/docs/python/current/addresses/verify.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/api-keys/retrieve.py
+++ b/official/docs/python/current/api-keys/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/batches/add-shipments.py
+++ b/official/docs/python/current/batches/add-shipments.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/batches/buy.py
+++ b/official/docs/python/current/batches/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/batches/create.py
+++ b/official/docs/python/current/batches/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/batches/label.py
+++ b/official/docs/python/current/batches/label.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/batches/list.py
+++ b/official/docs/python/current/batches/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/batches/remove-shipments.py
+++ b/official/docs/python/current/batches/remove-shipments.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/batches/retrieve.py
+++ b/official/docs/python/current/batches/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/batches/scan-forms.py
+++ b/official/docs/python/current/batches/scan-forms.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/billing/create-ep-credit-card.py
+++ b/official/docs/python/current/billing/create-ep-credit-card.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/billing/delete.py
+++ b/official/docs/python/current/billing/delete.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/billing/fund.py
+++ b/official/docs/python/current/billing/fund.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/billing/list.py
+++ b/official/docs/python/current/billing/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/brand/update.py
+++ b/official/docs/python/current/brand/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carbon-offset/buy.py
+++ b/official/docs/python/current/carbon-offset/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carbon-offset/create.py
+++ b/official/docs/python/current/carbon-offset/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carbon-offset/one-call-buy.py
+++ b/official/docs/python/current/carbon-offset/one-call-buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carrier-accounts/create.py
+++ b/official/docs/python/current/carrier-accounts/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carrier-accounts/delete.py
+++ b/official/docs/python/current/carrier-accounts/delete.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carrier-accounts/list.py
+++ b/official/docs/python/current/carrier-accounts/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carrier-accounts/retrieve.py
+++ b/official/docs/python/current/carrier-accounts/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carrier-accounts/update.py
+++ b/official/docs/python/current/carrier-accounts/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carrier-metadata/retrieve.py
+++ b/official/docs/python/current/carrier-metadata/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/carrier-types/list.py
+++ b/official/docs/python/current/carrier-types/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/child-users/create.py
+++ b/official/docs/python/current/child-users/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/child-users/delete.py
+++ b/official/docs/python/current/child-users/delete.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/customs-infos/create.py
+++ b/official/docs/python/current/customs-infos/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/customs-infos/retrieve.py
+++ b/official/docs/python/current/customs-infos/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/customs-items/create.py
+++ b/official/docs/python/current/customs-items/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/customs-items/retrieve.py
+++ b/official/docs/python/current/customs-items/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/endshipper/buy.py
+++ b/official/docs/python/current/endshipper/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/endshipper/create.py
+++ b/official/docs/python/current/endshipper/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/endshipper/list.py
+++ b/official/docs/python/current/endshipper/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/endshipper/retrieve.py
+++ b/official/docs/python/current/endshipper/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/endshipper/update.py
+++ b/official/docs/python/current/endshipper/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/events/list.py
+++ b/official/docs/python/current/events/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/events/retrieve.py
+++ b/official/docs/python/current/events/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/forms/create.py
+++ b/official/docs/python/current/forms/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/insurance/create.py
+++ b/official/docs/python/current/insurance/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/insurance/list.py
+++ b/official/docs/python/current/insurance/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/insurance/retrieve.py
+++ b/official/docs/python/current/insurance/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/options/create-with-options.py
+++ b/official/docs/python/current/options/create-with-options.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/orders/buy.py
+++ b/official/docs/python/current/orders/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/orders/create.py
+++ b/official/docs/python/current/orders/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/orders/one-call-buy.py
+++ b/official/docs/python/current/orders/one-call-buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/orders/retrieve.py
+++ b/official/docs/python/current/orders/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/parcels/create.py
+++ b/official/docs/python/current/parcels/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/parcels/retrieve.py
+++ b/official/docs/python/current/parcels/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/payloads/list.py
+++ b/official/docs/python/current/payloads/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/payloads/retrieve.py
+++ b/official/docs/python/current/payloads/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/pickups/buy.py
+++ b/official/docs/python/current/pickups/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/pickups/cancel.py
+++ b/official/docs/python/current/pickups/cancel.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/pickups/create.py
+++ b/official/docs/python/current/pickups/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/pickups/list.py
+++ b/official/docs/python/current/pickups/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/pickups/retrieve.py
+++ b/official/docs/python/current/pickups/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/rates/regenerate.py
+++ b/official/docs/python/current/rates/regenerate.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/rates/retrieve-stateless.py
+++ b/official/docs/python/current/rates/retrieve-stateless.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/rates/retrieve.py
+++ b/official/docs/python/current/rates/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/referral-customers/add-payment-method-with-bank-account.py
+++ b/official/docs/python/current/referral-customers/add-payment-method-with-bank-account.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/referral-customers/add-payment-method-with-credit-card.py
+++ b/official/docs/python/current/referral-customers/add-payment-method-with-credit-card.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/referral-customers/create.py
+++ b/official/docs/python/current/referral-customers/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/referral-customers/list.py
+++ b/official/docs/python/current/referral-customers/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/referral-customers/refund-by-amount.py
+++ b/official/docs/python/current/referral-customers/refund-by-amount.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/referral-customers/refund-by-payment-log.py
+++ b/official/docs/python/current/referral-customers/refund-by-payment-log.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/referral-customers/update.py
+++ b/official/docs/python/current/referral-customers/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/refunds/create.py
+++ b/official/docs/python/current/refunds/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/refunds/list.py
+++ b/official/docs/python/current/refunds/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/refunds/retrieve.py
+++ b/official/docs/python/current/refunds/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/reports/create.py
+++ b/official/docs/python/current/reports/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/reports/list.py
+++ b/official/docs/python/current/reports/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/reports/retrieve.py
+++ b/official/docs/python/current/reports/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/returns/create.py
+++ b/official/docs/python/current/returns/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/scan-form/create.py
+++ b/official/docs/python/current/scan-form/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/scan-form/list.py
+++ b/official/docs/python/current/scan-form/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/scan-form/retrieve.py
+++ b/official/docs/python/current/scan-form/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/shipments/buy.py
+++ b/official/docs/python/current/shipments/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/shipments/create.py
+++ b/official/docs/python/current/shipments/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/shipments/label.py
+++ b/official/docs/python/current/shipments/label.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/shipments/list.py
+++ b/official/docs/python/current/shipments/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/shipments/one-call-buy.py
+++ b/official/docs/python/current/shipments/one-call-buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/shipments/retrieve.py
+++ b/official/docs/python/current/shipments/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/shipping-insurance/insure.py
+++ b/official/docs/python/current/shipping-insurance/insure.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/shipping-refund/refund.py
+++ b/official/docs/python/current/shipping-refund/refund.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/smartrate/retrieve-estimated-delivery-date.py
+++ b/official/docs/python/current/smartrate/retrieve-estimated-delivery-date.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/smartrate/retrieve-time-in-transit-statistics.py
+++ b/official/docs/python/current/smartrate/retrieve-time-in-transit-statistics.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/tax-identifiers/create.py
+++ b/official/docs/python/current/tax-identifiers/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/trackers/create.py
+++ b/official/docs/python/current/trackers/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/trackers/list.py
+++ b/official/docs/python/current/trackers/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/trackers/retrieve.py
+++ b/official/docs/python/current/trackers/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/users/retrieve.py
+++ b/official/docs/python/current/users/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/users/update.py
+++ b/official/docs/python/current/users/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/webhooks/create.py
+++ b/official/docs/python/current/webhooks/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/webhooks/delete.py
+++ b/official/docs/python/current/webhooks/delete.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/webhooks/list.py
+++ b/official/docs/python/current/webhooks/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/webhooks/retrieve.py
+++ b/official/docs/python/current/webhooks/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/current/webhooks/update.py
+++ b/official/docs/python/current/webhooks/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/docs/python/v7/addresses/create-and-verify.py
+++ b/official/docs/python/v7/addresses/create-and-verify.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/addresses/create.py
+++ b/official/docs/python/v7/addresses/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/addresses/list.py
+++ b/official/docs/python/v7/addresses/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/addresses/retrieve.py
+++ b/official/docs/python/v7/addresses/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/addresses/verify-failure.py
+++ b/official/docs/python/v7/addresses/verify-failure.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/addresses/verify-param.py
+++ b/official/docs/python/v7/addresses/verify-param.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/addresses/verify-strict-param.py
+++ b/official/docs/python/v7/addresses/verify-strict-param.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/addresses/verify.py
+++ b/official/docs/python/v7/addresses/verify.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/api-keys/retrieve.py
+++ b/official/docs/python/v7/api-keys/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/batches/add-shipments.py
+++ b/official/docs/python/v7/batches/add-shipments.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/batches/buy.py
+++ b/official/docs/python/v7/batches/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/batches/create.py
+++ b/official/docs/python/v7/batches/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/batches/label.py
+++ b/official/docs/python/v7/batches/label.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/batches/list.py
+++ b/official/docs/python/v7/batches/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/batches/remove-shipments.py
+++ b/official/docs/python/v7/batches/remove-shipments.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/batches/retrieve.py
+++ b/official/docs/python/v7/batches/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/batches/scan-forms.py
+++ b/official/docs/python/v7/batches/scan-forms.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/billing/create-ep-credit-card.py
+++ b/official/docs/python/v7/billing/create-ep-credit-card.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/billing/delete.py
+++ b/official/docs/python/v7/billing/delete.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/billing/fund.py
+++ b/official/docs/python/v7/billing/fund.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/billing/list.py
+++ b/official/docs/python/v7/billing/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/brand/update.py
+++ b/official/docs/python/v7/brand/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carbon-offset/buy.py
+++ b/official/docs/python/v7/carbon-offset/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carbon-offset/create.py
+++ b/official/docs/python/v7/carbon-offset/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carbon-offset/one-call-buy.py
+++ b/official/docs/python/v7/carbon-offset/one-call-buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carrier-accounts/create.py
+++ b/official/docs/python/v7/carrier-accounts/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carrier-accounts/delete.py
+++ b/official/docs/python/v7/carrier-accounts/delete.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carrier-accounts/list.py
+++ b/official/docs/python/v7/carrier-accounts/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carrier-accounts/retrieve.py
+++ b/official/docs/python/v7/carrier-accounts/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carrier-accounts/update.py
+++ b/official/docs/python/v7/carrier-accounts/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carrier-metadata/retrieve.py
+++ b/official/docs/python/v7/carrier-metadata/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/carrier-types/list.py
+++ b/official/docs/python/v7/carrier-types/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/child-users/create.py
+++ b/official/docs/python/v7/child-users/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/child-users/delete.py
+++ b/official/docs/python/v7/child-users/delete.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/customs-infos/create.py
+++ b/official/docs/python/v7/customs-infos/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/customs-infos/retrieve.py
+++ b/official/docs/python/v7/customs-infos/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/customs-items/create.py
+++ b/official/docs/python/v7/customs-items/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/customs-items/retrieve.py
+++ b/official/docs/python/v7/customs-items/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/endshipper/buy.py
+++ b/official/docs/python/v7/endshipper/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/endshipper/create.py
+++ b/official/docs/python/v7/endshipper/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/endshipper/list.py
+++ b/official/docs/python/v7/endshipper/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/endshipper/retrieve.py
+++ b/official/docs/python/v7/endshipper/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/endshipper/update.py
+++ b/official/docs/python/v7/endshipper/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/events/list.py
+++ b/official/docs/python/v7/events/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/events/retrieve.py
+++ b/official/docs/python/v7/events/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/forms/create.py
+++ b/official/docs/python/v7/forms/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/insurance/create.py
+++ b/official/docs/python/v7/insurance/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/insurance/list.py
+++ b/official/docs/python/v7/insurance/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/insurance/retrieve.py
+++ b/official/docs/python/v7/insurance/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/options/create-with-options.py
+++ b/official/docs/python/v7/options/create-with-options.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/orders/buy.py
+++ b/official/docs/python/v7/orders/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/orders/create.py
+++ b/official/docs/python/v7/orders/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/orders/one-call-buy.py
+++ b/official/docs/python/v7/orders/one-call-buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/orders/retrieve.py
+++ b/official/docs/python/v7/orders/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/parcels/create.py
+++ b/official/docs/python/v7/parcels/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/parcels/retrieve.py
+++ b/official/docs/python/v7/parcels/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/payloads/list.py
+++ b/official/docs/python/v7/payloads/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/payloads/retrieve.py
+++ b/official/docs/python/v7/payloads/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/pickups/buy.py
+++ b/official/docs/python/v7/pickups/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/pickups/cancel.py
+++ b/official/docs/python/v7/pickups/cancel.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/pickups/create.py
+++ b/official/docs/python/v7/pickups/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/pickups/list.py
+++ b/official/docs/python/v7/pickups/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/pickups/retrieve.py
+++ b/official/docs/python/v7/pickups/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/rates/regenerate.py
+++ b/official/docs/python/v7/rates/regenerate.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/rates/retrieve-stateless.py
+++ b/official/docs/python/v7/rates/retrieve-stateless.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/rates/retrieve.py
+++ b/official/docs/python/v7/rates/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/referral-customers/add-payment-method-with-bank-account.py
+++ b/official/docs/python/v7/referral-customers/add-payment-method-with-bank-account.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/referral-customers/add-payment-method-with-credit-card.py
+++ b/official/docs/python/v7/referral-customers/add-payment-method-with-credit-card.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/referral-customers/create.py
+++ b/official/docs/python/v7/referral-customers/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/referral-customers/list.py
+++ b/official/docs/python/v7/referral-customers/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/referral-customers/refund-by-amount.py
+++ b/official/docs/python/v7/referral-customers/refund-by-amount.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/referral-customers/refund-by-payment-log.py
+++ b/official/docs/python/v7/referral-customers/refund-by-payment-log.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/referral-customers/update.py
+++ b/official/docs/python/v7/referral-customers/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/refunds/create.py
+++ b/official/docs/python/v7/refunds/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/refunds/list.py
+++ b/official/docs/python/v7/refunds/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/refunds/retrieve.py
+++ b/official/docs/python/v7/refunds/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/reports/create.py
+++ b/official/docs/python/v7/reports/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/reports/list.py
+++ b/official/docs/python/v7/reports/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/reports/retrieve.py
+++ b/official/docs/python/v7/reports/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/returns/create.py
+++ b/official/docs/python/v7/returns/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/scan-form/create.py
+++ b/official/docs/python/v7/scan-form/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/scan-form/list.py
+++ b/official/docs/python/v7/scan-form/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/scan-form/retrieve.py
+++ b/official/docs/python/v7/scan-form/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/shipments/buy.py
+++ b/official/docs/python/v7/shipments/buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/shipments/create.py
+++ b/official/docs/python/v7/shipments/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/shipments/label.py
+++ b/official/docs/python/v7/shipments/label.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/shipments/list.py
+++ b/official/docs/python/v7/shipments/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/shipments/one-call-buy.py
+++ b/official/docs/python/v7/shipments/one-call-buy.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/shipments/retrieve.py
+++ b/official/docs/python/v7/shipments/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/shipping-insurance/insure.py
+++ b/official/docs/python/v7/shipping-insurance/insure.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/shipping-refund/refund.py
+++ b/official/docs/python/v7/shipping-refund/refund.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/smartrate/retrieve-estimated-delivery-date.py
+++ b/official/docs/python/v7/smartrate/retrieve-estimated-delivery-date.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/smartrate/retrieve-time-in-transit-statistics.py
+++ b/official/docs/python/v7/smartrate/retrieve-time-in-transit-statistics.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/tax-identifiers/create.py
+++ b/official/docs/python/v7/tax-identifiers/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/trackers/create.py
+++ b/official/docs/python/v7/trackers/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/trackers/list.py
+++ b/official/docs/python/v7/trackers/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/trackers/retrieve.py
+++ b/official/docs/python/v7/trackers/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/users/retrieve.py
+++ b/official/docs/python/v7/users/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/users/update.py
+++ b/official/docs/python/v7/users/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/webhooks/create.py
+++ b/official/docs/python/v7/webhooks/create.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/webhooks/delete.py
+++ b/official/docs/python/v7/webhooks/delete.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/webhooks/list.py
+++ b/official/docs/python/v7/webhooks/list.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/webhooks/retrieve.py
+++ b/official/docs/python/v7/webhooks/retrieve.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/docs/python/v7/webhooks/update.py
+++ b/official/docs/python/v7/webhooks/update.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/guides/customs-guide/python/create-customs-info.py
+++ b/official/guides/customs-guide/python/create-customs-info.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 customs_info = easypost.CustomsInfo.create(
     eel_pfc="NOEEI 30.37(a)",
     customs_certify=True,

--- a/official/guides/customs-guide/python/create-customs-item.py
+++ b/official/guides/customs-guide/python/create-customs-item.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 customs_item1 = easypost.CustomsItem.create(
     description="T-shirt",
     quantity=1,

--- a/official/guides/customs-guide/python/create-international-shipment.py
+++ b/official/guides/customs-guide/python/create-international-shipment.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 easypost.Shipment.create(
     to_address={
         "name": "Tim Canterbury",

--- a/official/guides/errors-guide/python/catch-error.py
+++ b/official/guides/errors-guide/python/catch-error.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 try:
     easypost.Address.create({"strict_verify": True})
 except easypost.Error as e:

--- a/official/guides/getting-started/python/create_from_address.py
+++ b/official/guides/getting-started/python/create_from_address.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 easypost.api_key = "<YOUR_TEST/PRODUCTION_API_KEY>"
 
 fromAddress = easypost.Address.create(

--- a/official/guides/partner-white-label-guide/python/configure-recharge.py
+++ b/official/guides/partner-white-label-guide/python/configure-recharge.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 easypost.api_key = "<YOUR_PRODUCTION_API_KEY>"
 
 me = easypost.User.retrieve()

--- a/official/guides/partner-white-label-guide/python/create-referral-user.py
+++ b/official/guides/partner-white-label-guide/python/create-referral-user.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/guides/partner-white-label-guide/python/fund-wallet.py
+++ b/official/guides/partner-white-label-guide/python/fund-wallet.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 easypost.api_key = "<YOUR_PRODUCTION_API_KEY>"
 
 success = easypost.Billing.fund_wallet(

--- a/official/guides/partner-white-label-guide/python/update-referral-user-email.py
+++ b/official/guides/partner-white-label-guide/python/update-referral-user-email.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 easypost.api_key = os.getenv("EASYPOST_API_KEY")
 

--- a/official/guides/rate-limiting/retry_and_backoff.py
+++ b/official/guides/rate-limiting/retry_and_backoff.py
@@ -1,7 +1,6 @@
 import requests
 from urllib3.util.retry import Retry
 
-
 retry_strategy = Retry(
     total=3,
     backoff_factor=1,

--- a/official/guides/sms-tracking-tutorial/step2a.py
+++ b/official/guides/sms-tracking-tutorial/step2a.py
@@ -2,7 +2,6 @@ import easypost
 from flask import Flask
 from twilio.rest import TwilioRestClient
 
-
 app = Flask(__name__)
 app.config.from_object("config")
 

--- a/official/guides/tracking-guide/python/create-shipment.py
+++ b/official/guides/tracking-guide/python/create-shipment.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 easypost.api_key = "<YOUR_TEST/PRODUCTION_API_KEY>"
 
 shipment = easypost.Shipment.create(

--- a/official/guides/webhooks-guide/python/create.py
+++ b/official/guides/webhooks-guide/python/create.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 easypost.api_key = "<YOUR_TEST/PRODUCTION_API_KEY>"
 
 webhook = easypost.Webhook.create(

--- a/official/landing_pages/built_for_developers/create_shipment.py
+++ b/official/landing_pages/built_for_developers/create_shipment.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/landing_pages/built_for_developers/create_tracker.py
+++ b/official/landing_pages/built_for_developers/create_tracker.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/landing_pages/carbon_offset/create_shipment_with_carbon_offset.py
+++ b/official/landing_pages/carbon_offset/create_shipment_with_carbon_offset.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/landing_pages/carrier_language_api/buy-label.py
+++ b/official/landing_pages/carrier_language_api/buy-label.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 

--- a/official/landing_pages/shipping_insurance/insure_shipment.py
+++ b/official/landing_pages/shipping_insurance/insure_shipment.py
@@ -1,7 +1,5 @@
-import os
-
 import easypost
-
+import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 


### PR DESCRIPTION
After looking at the snippets on the site, it appears these linebreaks after imports although good in real code are undesirable for snippets. Removing them.

Using the CLI args in this repo alone maintains our style guide for other repos that use it while getting rid of the issues for just the examples here.