### PR TITLE
fix: retry example

### DIFF
--- a/official/guides/rate-limiting/retry_and_backoff.py
+++ b/official/guides/rate-limiting/retry_and_backoff.py
@@ -1,6 +1,7 @@
 import requests
 from urllib3.util.retry import Retry
 
+
 retry_strategy = Retry(
     total=3,
     backoff_factor=1,
@@ -11,12 +12,11 @@ retry_strategy = Retry(
         503,
         504,
     ],
-    method_whitelist=[
+    allowed_methods=[
         "DELETE",
         "GET",
     ],
 )
-adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
 requests_session = requests.Session()
 requests_http_adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
 requests_session.mount(prefix="https://api.easypost.com", adapter=requests_http_adapter)

--- a/official/guides/rate-limiting/retry_and_backoff.py
+++ b/official/guides/rate-limiting/retry_and_backoff.py
@@ -1,7 +1,6 @@
 import requests
 from urllib3.util.retry import Retry
 
-
 retry_strategy = Retry(
     total=3,
     backoff_factor=1,

--- a/official/guides/rate-limiting/retry_and_backoff.py
+++ b/official/guides/rate-limiting/retry_and_backoff.py
@@ -19,4 +19,4 @@ retry_strategy = Retry(
 )
 requests_session = requests.Session()
 requests_http_adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
-requests_session.mount(prefix="https://api.easypost.com", adapter=requests_http_adapter)
+requests_session.mount(prefix="https://", adapter=requests_http_adapter)


### PR DESCRIPTION
I played around with our retry example and found a param that was deprecated and renamed and a line that isn't even used. Fixed
