### PR TITLE
Add missing API key retrieval examples

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/EasyPost/easypost-go/v2 v2.20.0
-	github.com/EasyPost/easypost-go/v3 v3.0.0
+	github.com/EasyPost/easypost-go/v3 v3.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/EasyPost/easypost-go/v2 v2.20.0 h1:DSqpwwTq2XDLg3Nlfk9KSoMHNEyZsqJSyMrH2ghjAmc=
 github.com/EasyPost/easypost-go/v2 v2.20.0/go.mod h1:+C9K2M4jvFSvN06xYXM2qom4zxmxPDTObQHu++C3hCs=
-github.com/EasyPost/easypost-go/v3 v3.0.0 h1:MVyYFFAIJyQdiZFTejmNlIqwaQGeVilQkVyxpwPxutU=
-github.com/EasyPost/easypost-go/v3 v3.0.0/go.mod h1:WDD0qkjwxedVKFXCcdJBz22rtRHpuxjGazgSVcTfdIw=
 github.com/EasyPost/easypost-go/v3 v3.2.0 h1:dNWmPG1AkpgYFJxhw/zGzCz1JOVXPpNIi8+JND4UHzk=
 github.com/EasyPost/easypost-go/v3 v3.2.0/go.mod h1:WDD0qkjwxedVKFXCcdJBz22rtRHpuxjGazgSVcTfdIw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/EasyPost/easypost-go/v2 v2.20.0 h1:DSqpwwTq2XDLg3Nlfk9KSoMHNEyZsqJSyM
 github.com/EasyPost/easypost-go/v2 v2.20.0/go.mod h1:+C9K2M4jvFSvN06xYXM2qom4zxmxPDTObQHu++C3hCs=
 github.com/EasyPost/easypost-go/v3 v3.0.0 h1:MVyYFFAIJyQdiZFTejmNlIqwaQGeVilQkVyxpwPxutU=
 github.com/EasyPost/easypost-go/v3 v3.0.0/go.mod h1:WDD0qkjwxedVKFXCcdJBz22rtRHpuxjGazgSVcTfdIw=
+github.com/EasyPost/easypost-go/v3 v3.2.0 h1:dNWmPG1AkpgYFJxhw/zGzCz1JOVXPpNIi8+JND4UHzk=
+github.com/EasyPost/easypost-go/v3 v3.2.0/go.mod h1:WDD0qkjwxedVKFXCcdJBz22rtRHpuxjGazgSVcTfdIw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=

--- a/official/docs/csharp/current/api-keys/retrieve.cs
+++ b/official/docs/csharp/current/api-keys/retrieve.cs
@@ -18,6 +18,11 @@ namespace EasyPostExamples
             List<ApiKey> apiKeys = await client.ApiKey.All();
 
             Console.WriteLine(JsonConvert.SerializeObject(apiKeys, Formatting.Indented));
+
+            // Retrieve API keys for a specific child user
+            List<ApiKey> childApiKeys = await client.ApiKey.RetrieveApiKeysForUser("user_...");
+
+            Console.WriteLine(JsonConvert.SerializeObject(childApiKeys, Formatting.Indented));
         }
     }
 }

--- a/official/docs/csharp/current/api-keys/retrieve.cs
+++ b/official/docs/csharp/current/api-keys/retrieve.cs
@@ -15,6 +15,7 @@ namespace EasyPostExamples
 
             var client = new EasyPost.Client(apiKey);
 
+            // Retrieve all API keys including children
             List<ApiKey> apiKeys = await client.ApiKey.All();
 
             Console.WriteLine(JsonConvert.SerializeObject(apiKeys, Formatting.Indented));

--- a/official/docs/golang/current/api-keys/retrieve.go
+++ b/official/docs/golang/current/api-keys/retrieve.go
@@ -11,7 +11,13 @@ func main() {
 	apiKey := os.Getenv("EASYPOST_API_KEY")
 	client := easypost.New(apiKey)
 
+	// Retrieve all API keys including children
 	apiKeys, _ := client.GetAPIKeys()
 
 	fmt.Println(apiKeys)
+
+	// Retrieve API keys for a specific child user
+	childApiKeys, _ := client.GetAPIKeysForUser("user_...")
+
+	fmt.Println(childApiKeys)
 }

--- a/official/docs/java/current/api-keys/retrieve.java
+++ b/official/docs/java/current/api-keys/retrieve.java
@@ -11,5 +11,10 @@ public class Retrieve {
         ApiKeys parentKeys = client.apikeys.all();
 
         System.out.println(parentKeys);
+
+        // Retrieve API keys for a specific child user
+        ApiKeys childKeys = client.user.apiKeys("user_...");
+
+        System.out.println(childKeys);
     }
 }

--- a/official/docs/java/current/api-keys/retrieve.java
+++ b/official/docs/java/current/api-keys/retrieve.java
@@ -8,12 +8,12 @@ public class Retrieve {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient(System.getenv("EASYPOST_API_KEY"));
 
-        ApiKeys parentKeys = client.apikeys.all();
+        ApiKeys parentKeys = client.apiKey.all();
 
         System.out.println(parentKeys);
 
         // Retrieve API keys for a specific child user
-        ApiKeys childKeys = client.user.apiKeys("user_...");
+        ApiKeys childKeys = client.apiKey.retrieveApiKeysForUser("user_...");
 
         System.out.println(childKeys);
     }

--- a/official/docs/java/current/api-keys/retrieve.java
+++ b/official/docs/java/current/api-keys/retrieve.java
@@ -8,6 +8,7 @@ public class Retrieve {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient(System.getenv("EASYPOST_API_KEY"));
 
+        // Retrieve all API keys including children
         ApiKeys parentKeys = client.apiKey.all();
 
         System.out.println(parentKeys);

--- a/official/docs/node/current/api-keys/retrieve.js
+++ b/official/docs/node/current/api-keys/retrieve.js
@@ -3,13 +3,13 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient(process.env.EASYPOST_API_KEY);
 
 (async () => {
-  let apiKeys;
-
   // Retrieve all API keys including children
-  apiKeys = await client.ApiKey.all();
-
-  // Retrieve API keys for a specific child user
-  client.User.apiKeys('user_...').then((childApiKeys) => console.log(childApiKeys));
+  let apiKeys = await client.ApiKey.all();
 
   console.log(apiKeys);
+
+  // Retrieve API keys for a specific child user
+  let childApiKeys = await client.ApiKey.retrieveApiKeysForUser('user_...');
+
+  console.log(childApiKeys);
 })();

--- a/official/docs/node/current/api-keys/retrieve.js
+++ b/official/docs/node/current/api-keys/retrieve.js
@@ -9,7 +9,7 @@ const client = new EasyPostClient(process.env.EASYPOST_API_KEY);
   apiKeys = await client.ApiKey.all();
 
   // Retrieve API keys for a specific child user
-  api.User.apiKeys('user_...').then((childApiKeys) => console.log(childApiKeys));
+  client.User.apiKeys('user_...').then((childApiKeys) => console.log(childApiKeys));
 
   console.log(apiKeys);
 })();

--- a/official/docs/node/current/api-keys/retrieve.js
+++ b/official/docs/node/current/api-keys/retrieve.js
@@ -9,7 +9,7 @@ const client = new EasyPostClient(process.env.EASYPOST_API_KEY);
   apiKeys = await client.ApiKey.all();
 
   // Retrieve API keys for a specific child user
-  apiKeys = await client.User.retrieve('user_...');
+  api.User.apiKeys('user_...').then((childApiKeys) => console.log(childApiKeys));
 
   console.log(apiKeys);
 })();

--- a/official/docs/php/current/api-keys/retrieve.php
+++ b/official/docs/php/current/api-keys/retrieve.php
@@ -3,10 +3,12 @@
 $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
 // Retrieve all API keys (authenticated user and child user keys)
-$apiKeys = $client->user->allApiKeys();
+$apiKeys = $client->apiKeys->all();
+
+echo $apiKeys;
 
 // Retrieve API keys for a child user
 $childUser = $client->user->retrieve('user_...');
-$apiKeys = $client->user->apiKeys($childUser->id);
+$childApiKeys = $client->apiKeys->retrieveApiKeysForUser($childUser->id);
 
-echo $apiKeys;
+echo $childApiKeys;

--- a/official/docs/php/current/api-keys/retrieve.php
+++ b/official/docs/php/current/api-keys/retrieve.php
@@ -8,7 +8,6 @@ $apiKeys = $client->apiKeys->all();
 echo $apiKeys;
 
 // Retrieve API keys for a specific child user
-$childUser = $client->user->retrieve('user_...');
-$childApiKeys = $client->apiKeys->retrieveApiKeysForUser($childUser->id);
+$childApiKeys = $client->apiKeys->retrieveApiKeysForUser('user_...');
 
 echo $childApiKeys;

--- a/official/docs/php/current/api-keys/retrieve.php
+++ b/official/docs/php/current/api-keys/retrieve.php
@@ -2,12 +2,12 @@
 
 $client = new \EasyPost\EasyPostClient(getenv('EASYPOST_API_KEY'));
 
-// Retrieve all API keys (authenticated user and child user keys)
+// Retrieve all API keys including children
 $apiKeys = $client->apiKeys->all();
 
 echo $apiKeys;
 
-// Retrieve API keys for a child user
+// Retrieve API keys for a specific child user
 $childUser = $client->user->retrieve('user_...');
 $childApiKeys = $client->apiKeys->retrieveApiKeysForUser($childUser->id);
 

--- a/official/docs/python/current/api-keys/retrieve.py
+++ b/official/docs/python/current/api-keys/retrieve.py
@@ -4,10 +4,12 @@ import os
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 
 # Retrieve all API keys (authenticated user and child user keys)
-api_keys = client.user.all_api_keys()
+api_keys = client.api_key.all()
+
+print(api_keys)
 
 # Retrieve API keys for a child user
 child_user = client.user.retrieve("user_...")
-api_keys = client.user.api_keys(child_user.id)
+child_api_keys = client.api_key.retrieve_api_keys_for_user(child_user.id)
 
-print(api_keys)
+print(child_api_keys)

--- a/official/docs/python/current/api-keys/retrieve.py
+++ b/official/docs/python/current/api-keys/retrieve.py
@@ -3,12 +3,12 @@ import os
 
 client = easypost.EasyPostClient(os.getenv("EASYPOST_API_KEY"))
 
-# Retrieve all API keys (authenticated user and child user keys)
+# Retrieve all API keys including children
 api_keys = client.api_key.all()
 
 print(api_keys)
 
-# Retrieve API keys for a child user
+# Retrieve API keys for a specific child user
 child_user = client.user.retrieve("user_...")
 child_api_keys = client.api_key.retrieve_api_keys_for_user(child_user.id)
 

--- a/official/docs/python/current/api-keys/retrieve.py
+++ b/official/docs/python/current/api-keys/retrieve.py
@@ -9,7 +9,6 @@ api_keys = client.api_key.all()
 print(api_keys)
 
 # Retrieve API keys for a specific child user
-child_user = client.user.retrieve("user_...")
-child_api_keys = client.api_key.retrieve_api_keys_for_user(child_user.id)
+child_api_keys = client.api_key.retrieve_api_keys_for_user("user_...")
 
 print(child_api_keys)

--- a/official/docs/ruby/current/api-keys/retrieve.rb
+++ b/official/docs/ruby/current/api-keys/retrieve.rb
@@ -8,7 +8,6 @@ api_keys = client.api_key.all
 puts api_keys
 
 # Retrieve API keys for a specific child user
-child_user = client.user.retrieve('user_...')
-child_api_keys = client.api_key.retrieve_api_keys_for_user(child_user.id)
+child_api_keys = client.api_key.retrieve_api_keys_for_user('user_...')
 
 puts child_api_keys

--- a/official/docs/ruby/current/api-keys/retrieve.rb
+++ b/official/docs/ruby/current/api-keys/retrieve.rb
@@ -2,12 +2,12 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: ENV['EASYPOST_API_KEY'])
 
-# Retrieve all API keys (authenticated user and child user keys)
+# Retrieve all API keys including children
 api_keys = client.api_key.all
 
 puts api_keys
 
-# Retrieve API keys for a child user
+# Retrieve API keys for a specific child user
 child_user = client.user.retrieve('user_...')
 child_api_keys = client.api_key.retrieve_api_keys_for_user(child_user.id)
 

--- a/official/docs/ruby/current/api-keys/retrieve.rb
+++ b/official/docs/ruby/current/api-keys/retrieve.rb
@@ -3,10 +3,12 @@ require 'easypost'
 client = EasyPost::Client.new(api_key: ENV['EASYPOST_API_KEY'])
 
 # Retrieve all API keys (authenticated user and child user keys)
-api_keys = client.user.all_api_keys
+api_keys = client.api_key.all
+
+puts api_keys
 
 # Retrieve API keys for a child user
 child_user = client.user.retrieve('user_...')
-api_keys = client.user.api_keys(child_user.id)
+child_api_keys = client.api_key.retrieve_api_keys_for_user(child_user.id)
 
-puts api_keys
+puts child_api_keys


### PR DESCRIPTION
Now that the functions are available for a next release on C# and Node libraries, add examples to get API Keys for child users for these. It also add missing example for Java library, which already has that functionality.