### PR TITLE
[chore] Ignore CVE in DependencyCheck plugin dependency

### DIFF
--- a/style_guides/java/style_suppressions.xml
+++ b/style_guides/java/style_suppressions.xml
@@ -34,4 +34,13 @@
     <!-- General -->
     <!-- Don't do any CheckStyle checks on any non-Java files. -->
     <suppress files=".+\.(?:txt|xml|csv|sh|thrift|html|sql|eot|ttf|woff|css|png)$" checks=".*" />
+
+    <!-- Security -->
+    <!-- Ignore known vulnerability in JGit, used only by the DependencyCheck Maven plugin (not passed to end-users) -->
+    <!-- ref: https://github.com/jeremylong/DependencyCheck/issues/5943 -->
+    <suppress base="true">
+      <notes><![CDATA[FP per issue #5943]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.eclipse\.jgit/org\.eclipse\.jgit@.*$</packageUrl>
+      <cpe>cpe:/a:eclipse:jgit</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
The latest version of the Dependency Check plugin has a vulnerable dependency, which is a red herring for our testing. We will ignore this vulnerability for now, and update DependencyCheck when a new version comes out.

Ref: https://github.com/jeremylong/DependencyCheck/issues/5943