### PR TITLE
fix: catch error examples

### DIFF
--- a/official/guides/errors-guide/csharp/catch-error.cs
+++ b/official/guides/errors-guide/csharp/catch-error.cs
@@ -8,7 +8,7 @@ try
 }
   await Address.Create(parameters);
 }
-catch (EasyPost.HttpException e)
+catch (EasyPost.Exceptions.API.ApiError error)
 {
-    Console.Write(e.Code); // ADDRESS.VERIFY.FAILURE
+    Console.Write(error.Code); // ADDRESS.VERIFY.FAILURE
 }

--- a/official/guides/errors-guide/golang/catch-error.go
+++ b/official/guides/errors-guide/golang/catch-error.go
@@ -20,5 +20,7 @@ func main() {
         },
     )
 
-    fmt.Println(err.Code)
+    if err, ok := err.(*easypost.APIError); ok {
+        fmt.Println(err.Code)
+    }
 }

--- a/official/guides/errors-guide/golang/catch-error.go
+++ b/official/guides/errors-guide/golang/catch-error.go
@@ -20,5 +20,5 @@ func main() {
         },
     )
 
-    fmt.Println(err)
+    fmt.Println(err.Code)
 }

--- a/official/guides/errors-guide/java/catch-error.java
+++ b/official/guides/errors-guide/java/catch-error.java
@@ -3,7 +3,7 @@ package errors;
 import java.util.HashMap;
 
 import com.easypost.EasyPost;
-import com.easypost.exception.EasyPostException;
+import com.easypost.exception.APIException;
 
 public class CatchError {
     public static void main(String[] args) throws EasyPostException {
@@ -15,8 +15,8 @@ public class CatchError {
             address.put("verify_strict", true);
 
             Address.create(address);
-        } catch (EasyPostException e) {
-            System.err.println(e.getMessage());
+        } catch (APIException error) {
+            System.err.println(error.getCode());
         }
     }
 }

--- a/official/guides/errors-guide/node/catch-error.js
+++ b/official/guides/errors-guide/node/catch-error.js
@@ -3,6 +3,6 @@ const api = new Easypost('{API_KEY}');
 
 api.Address.save({
   strict_verify: true,
-}).catch((e) => {
-  console.log(e);
+}).catch((error) => {
+  console.error(error.code);
 });

--- a/official/guides/errors-guide/php/catch-error.php
+++ b/official/guides/errors-guide/php/catch-error.php
@@ -1,5 +1,9 @@
+<?php
+
 try {
-  \EasyPost\Address::create(array(..., "strict_verify" => true));
-catch (\EasyPost\Error $e) {
-  echo $e->ecode;
+    \EasyPost\Address::create([
+        "strict_verify" => true,
+    ]);
+} catch (\EasyPost\Exception\Api\ApiException $error) {
+    echo $error->code;
 }

--- a/official/guides/errors-guide/python/catch-error.py
+++ b/official/guides/errors-guide/python/catch-error.py
@@ -1,6 +1,5 @@
 import easypost
 
-
 try:
     easypost.Address.create({"strict_verify": True})
 except easypost.errors.api.ApiError as error:

--- a/official/guides/errors-guide/python/catch-error.py
+++ b/official/guides/errors-guide/python/catch-error.py
@@ -1,6 +1,7 @@
 import easypost
 
+
 try:
     easypost.Address.create({"strict_verify": True})
-except easypost.Error as e:
-    print(e.json_body["code"])
+except easypost.errors.api.ApiError as error:
+    print(error.code)

--- a/official/guides/errors-guide/ruby/catch-error.rb
+++ b/official/guides/errors-guide/ruby/catch-error.rb
@@ -2,6 +2,6 @@ require 'easypost'
 
 begin
   Address.create({}, strict_verify: true)
-rescue EasyPost::Errors::ApiError => error
-  p error.code
+rescue EasyPost::Errors::ApiError => e
+  p e.code
 end

--- a/official/guides/errors-guide/ruby/catch-error.rb
+++ b/official/guides/errors-guide/ruby/catch-error.rb
@@ -2,6 +2,6 @@ require 'easypost'
 
 begin
   Address.create({}, strict_verify: true)
-rescue EasyPost::Error => e
-  p e.code
+rescue EasyPost::Errors::ApiError => error
+  p error.code
 end


### PR DESCRIPTION
The examples for catching errors do not reflect the most recent releases of the libraries where we completely overhauled error handling. This PR updates the syntax to match.
