### PR TITLE
[chore] Ignore pre-formatted string suggestion in .NET 8.0

### DIFF
--- a/style_guides/csharp/.editorconfig
+++ b/style_guides/csharp/.editorconfig
@@ -672,3 +672,5 @@ dotnet_diagnostic.CA1014.severity = none
 dotnet_diagnostic.CA1822.severity = none
 ### Properties should not return arrays
 dotnet_diagnostic.CA1819.severity = none
+### Use pre-formatted strings in .NET 8.0
+dotnet_diagnostic.CA1863.severity = none


### PR DESCRIPTION
In .NET 8.0, it's encouraged to use [`CompositeFormat`](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1863) (pre-formatted string). This does not exist in older .NET versions, so we will globally suppress this for now.