### PR TITLE
[feat] Add `.http` files for API call references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository holds hundreds of code examples for using the EasyPost API acros
   - `fixtures` holds all of the test data used as fixtures in our client library test suites
   - `guides` holds all the code snippets that populate on our guides page. Each language will have its own subdirectory
   - `responses` holds all of the associated responses for our example snippets found in the `docs` directory that will give you a good idea of what to expect back from the EasyPost API
-- `community` holds code snippets contributed from the community. These may include custom workflows, how to integrate EasyPost with other software, etc
+- `community` holds code snippets contributed from the community. These may include custom workflows, how to integrate EasyPost with other software, etc. These are **unofficial** and **not supported or maintained by EasyPost**.
 
 ## Usage
 

--- a/community/docs/http_files/README.md
+++ b/community/docs/http_files/README.md
@@ -1,0 +1,5 @@
+These are `.http` files representing examples of HTTP requests that can be made to the API.
+
+They can be run using the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension
+in Visual Studio Code or the [HTTP Client](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html)
+in JetBrains IDEs. They can also be exported as cURL commands.

--- a/community/docs/http_files/addresses.http
+++ b/community/docs/http_files/addresses.http
@@ -1,0 +1,100 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create an Address
+POST https://api.easypost.com/v2/addresses
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "address": {
+    "street1": "417 MONTGOMERY ST",
+    "street2": "FLOOR 5",
+    "city": "SAN FRANCISCO",
+    "state": "CA",
+    "zip": "94104",
+    "country": "US",
+    "company": "EasyPost",
+    "phone": "415-123-4567"
+  }
+}
+
+###
+
+# Create and verify an Address in one call (basic verification checks)
+POST https://api.easypost.com/v2/addresses/create_and_verify
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "address": {
+    "street1": "000 unknown street",
+    "city": "Not A City",
+    "state": "ZZ",
+    "zip": "00001",
+    "country": "US",
+    "email": "test@example.com",
+    "phone": "5555555555"
+  }
+}
+
+###
+
+# Create and verify an Address in one call (basic + delivery/zip validation)
+POST https://api.easypost.com/v2/addresses/create
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "address": {
+    "street1": "000 unknown street",
+    "city": "Not A City",
+    "state": "ZZ",
+    "zip": "00001",
+    "country": "US",
+    "email": "test@example.com",
+    "phone": "5555555555"
+  },
+  "verify": true
+}
+
+###
+
+# Create and verify an Address in one call (basic + strict delivery/zip validation)
+POST https://api.easypost.com/v2/addresses/create
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "address": {
+    "street1": "000 unknown street",
+    "city": "Not A City",
+    "state": "ZZ",
+    "zip": "00001",
+    "country": "US",
+    "email": "test@example.com",
+    "phone": "5555555555"
+  },
+  "verify_strict": true
+}
+
+###
+
+# Verify an existing Address (basic verification checks)
+GET https://api.easypost.com/v2/addresses/{{ADDRESS_ID}}/verify
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retrieve an Address
+GET https://api.easypost.com/v2/addresses/{{ADDRESS_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all Addresses
+GET https://api.easypost.com/v2/addresses
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/api-keys.http
+++ b/community/docs/http_files/api-keys.http
@@ -1,0 +1,49 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a test API key
+POST https://api.easypost.com/v2/api_keys
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "mode": "test"
+}
+
+###
+
+# Create a production API key
+POST https://api.easypost.com/v2/api_keys
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "mode": "production"
+}
+
+###
+
+# Retrieve all API keys
+GET https://api.easypost.com/v2/api_keys
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Enable a disabled API key
+POST https://api.easypost.com/v2/api_keys/{{API_KEY_ID}}/enable
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Disable an enabled API key
+POST https://api.easypost.com/v2/api_keys/{{API_KEY_ID}}/disable
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Delete an API key
+DELETE https://api.easypost.com/v2/api_keys/{{API_KEY_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/batches.http
+++ b/community/docs/http_files/batches.http
@@ -1,0 +1,89 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a Batch with existing Shipments
+POST https://api.easypost.com/v2/batches
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "batch": {
+    "shipments": [
+      {
+        "id": "shp_123"
+      },
+      {
+        "id": "shp_456"
+      }
+    ]
+  }
+}
+
+###
+
+# Add Shipments to a Batch
+POST https://api.easypost.com/v2/batches/{{BATCH_ID}}/add_shipments
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipments": [
+    {
+      "id": "shp_789"
+    }
+  ]
+}
+
+###
+
+# Remove Shipments from a Batch
+POST https://api.easypost.com/v2/batches/{{BATCH_ID}}/remove_shipments
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipments": [
+    {
+      "id": "shp_789"
+    }
+  ]
+}
+
+###
+
+# Purchase a Batch
+POST https://api.easypost.com/v2/batches/{{BATCH_ID}}/buy
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Generate a label for a Batch
+POST https://api.easypost.com/v2/batches/{{BATCH_ID}}/label
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "file_format": "PDF"
+}
+
+###
+
+# Generate a ScanForm for a Batch
+POST https://api.easypost.com/v2/batches/{{BATCH_ID}}/scan_form
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retrieve a Batch
+GET https://api.easypost.com/v2/batches/{{BATCH_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all Batches
+GET https://api.easypost.com/v2/batches
+    ?page_size=5
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/billing.http
+++ b/community/docs/http_files/billing.http
@@ -1,0 +1,61 @@
+@partner_api_key = PARTNER_API_KEY
+@referral_customer_api_key = REFERRAL_CUSTOMER_API_KEY
+@API_KEY = EASYPOST_API_KEY
+
+# Get EasyPost public key for authenticating with Stripe
+GET https://api.easypost.com/v2/partners/stripe_public_key
+Authorization: Bearer {{partner_api_key}}
+Content-Type: application/json
+
+###
+
+# Add a Stripe credit card to referral customer's account
+POST https://api.easypost.com/v2/credit_cards
+Authorization: Bearer {{referral_customer_api_key}}
+Content-Type: application/json
+
+{
+  "credit_card": {
+    "stripe_object_id": "tok_...",
+    "priority": "primary"
+  }
+}
+
+###
+
+# List account payment methods
+GET https://api.easypost.com/v2/payment_methods
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Fund account with on-file credit card ($10.00)
+POST https://api.easypost.com/v2/credit_cards/{{CREDIT_CARD_ID}}/charges
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "amount": 1000
+}
+
+###
+
+# Fund account with on-file bank account ($10.00)
+POST https://api.easypost.com/v2/bank_accounts/{{BANK_ACCOUNT_ID}}/charges
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Delete an on-file credit card from account
+DELETE https://api.easypost.com/v2/credit_cards/{{CREDIT_CARD_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Delete an on-file bank account from account
+DELETE https://api.easypost.com/v2/bank_accounts/{{BANK_ACCOUNT_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/billing.http
+++ b/community/docs/http_files/billing.http
@@ -1,17 +1,17 @@
-@partner_api_key = PARTNER_API_KEY
-@referral_customer_api_key = REFERRAL_CUSTOMER_API_KEY
+@PARTNER_API_KEY = PARTNER_API_KEY
+@REFERRAL_CUSTOMER_API_KEY = REFERRAL_CUSTOMER_API_KEY
 @API_KEY = EASYPOST_API_KEY
 
 # Get EasyPost public key for authenticating with Stripe
 GET https://api.easypost.com/v2/partners/stripe_public_key
-Authorization: Bearer {{partner_api_key}}
+Authorization: Bearer {{PARTNER_API_KEY}}
 Content-Type: application/json
 
 ###
 
 # Add a Stripe credit card to referral customer's account
 POST https://api.easypost.com/v2/credit_cards
-Authorization: Bearer {{referral_customer_api_key}}
+Authorization: Bearer {{REFERRAL_CUSTOMER_API_KEY}}
 Content-Type: application/json
 
 {

--- a/community/docs/http_files/brands.http
+++ b/community/docs/http_files/brands.http
@@ -1,0 +1,18 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Update a user's brand
+PATCH https://api.easypost.com/v2/users/{{USER_ID}}/brand
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "brand": {
+    "background_color": "#FFFFFF",
+    "color": "#303F9F",
+    "logo": "data:image/png;base64,iVBORw0K...",
+    "logo_href": "https://easypost.com",
+    "ad": "null",
+    "ad_href": "null",
+    "theme": "theme1"
+  }
+}

--- a/community/docs/http_files/carrier-accounts.http
+++ b/community/docs/http_files/carrier-accounts.http
@@ -1,0 +1,63 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a Carrier Account
+POST https://api.easypost.com/v2/carrier_accounts
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "carrier_account": {
+    "type": "DhlEcsAccount",
+    "description": "CA Location DHL eCommerce Solutions Account",
+    "reference": "my-reference",
+    "credentials": {
+      "client_id": "123456",
+      "client_secret": "123abc",
+      "distribution_center": "USLAX1",
+      "pickup_id": "123456"
+    },
+    "test_credentials": {
+      "client_id": "123456",
+      "client_secret": "123abc",
+      "distribution_center": "USLAX1",
+      "pickup_id": "123456"
+    }
+  }
+}
+
+###
+
+# Retrieve a Carrier Account
+GET https://api.easypost.com/v2/carrier_accounts/{{CARRIER_ACCOUNT_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all Carrier Accounts
+GET https://api.easypost.com/v2/carrier_accounts
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Update a Carrier Account
+PATCH https://api.easypost.com/v2/carrier_accounts/{{CARRIER_ACCOUNT_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "carrier_account": {
+    "description": "FL Location DHL eCommerce Solutions Account",
+    "credentials": {
+      "pickup_id": "abc123"
+    }
+  }
+}
+
+###
+
+# Delete a Carrier Account
+DELETE https://api.easypost.com/v2/carrier_accounts/{{CARRIER_ACCOUNT_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/carrier-metadata.http
+++ b/community/docs/http_files/carrier-metadata.http
@@ -1,0 +1,31 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Retreive all metdata for all carriers
+GET https://api.easypost.com/v2/metadata/carriers
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retreive all metdata for a specific carrier (UPS)
+GET https://api.easypost.com/v2/metadata/carriers
+    ?carriers=usps
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retrieve specific metadata for all carriers (service levels and predefined packages)
+GET https://api.easypost.com/v2/metadata/carriers
+    ?type=service_levels,predefined_packages
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retrieve specific metadata for a specific carrier (service levels and predefined packages for UPS)
+GET https://api.easypost.com/v2/metadata/carriers
+    ?carriers=usps
+    &type=service_levels,predefined_packages
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/carrier-types.http
+++ b/community/docs/http_files/carrier-types.http
@@ -1,0 +1,6 @@
+@API_KEY = EASYPOST_API_KEY
+
+# List all carrier types
+GET https://api.easypost.com/v2/carrier_types
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/customs-infos.http
+++ b/community/docs/http_files/customs-infos.http
@@ -1,0 +1,34 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a customs info object
+POST https://api.easypost.com/v2/customs_infos
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "customs_info": {
+    "customs_certify": "true",
+    "customs_signer": "Steve Brule",
+    "contents_type": "merchandise",
+    "contents_explanation": "",
+    "restriction_type": "none",
+    "eel_pfc": "NOEEI 30.37(a)",
+    "customs_items": [
+      {
+        "description": "T-shirt",
+        "quantity": "1",
+        "weight": "5",
+        "value": "10",
+        "hs_tariff_number": "123456",
+        "origin_country": "US"
+      }
+    ]
+  }
+}
+
+###
+
+# Retrieve a customs info object
+GET https://api.easypost.com/v2/customs_infos/{{CUSTOMS_INFO_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/customs-items.http
+++ b/community/docs/http_files/customs-items.http
@@ -1,0 +1,24 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a customs item
+POST https://api.easypost.com/v2/customs_items
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "customs_item": {
+    "description": "T-shirt",
+    "quantity": "1",
+    "weight": "5",
+    "value": "10",
+    "hs_tariff_number": "123456",
+    "origin_country": "US"
+  }
+}
+
+###
+
+# Retrieve a customs item
+GET https://api.easypost.com/v2/customs_items/{{CUSTOMS_ITEM_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/endshippers.http
+++ b/community/docs/http_files/endshippers.http
@@ -1,0 +1,72 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create an EndShipper
+POST https://api.easypost.com/v2/end_shippers
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "address": {
+    "name": "FOO BAR",
+    "company": "BAZ",
+    "street1": "164 TOWNSEND STREET UNIT 1",
+    "street2": "UNIT 1",
+    "city": "SAN FRANCISCO",
+    "state": "CA",
+    "zip": "94107",
+    "country": "US",
+    "phone": "555-555-5555",
+    "email": "FOO@EXAMPLE.COM"
+  }
+}
+
+###
+
+# Retrieve an EndShipper
+GET https://api.easypost.com/v2/end_shippers/{{ENDSHIPPER_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all EndShippers
+GET https://api.easypost.com/v2/end_shippers
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Update an EndShipper
+PUT https://api.easypost.com/v2/end_shippers/{{ENDSHIPPER_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "address": {
+    "name": "NEW NAME",
+    "company": "BAZ",
+    "street1": "164 TOWNSEND STREET UNIT 1",
+    "street2": "UNIT 1",
+    "city": "SAN FRANCISCO",
+    "state": "CA",
+    "zip": "94107",
+    "country": "US",
+    "phone": "555-555-5555",
+    "email": "FOO@EXAMPLE.COM"
+  }
+}
+
+###
+
+# Buy a Shipment with an EndShipper
+POST https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/buy
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "rate": {
+    "id": "rate_123"
+  },
+  "end_shipper_id": "{{ENDSHIPPER_ID}}"
+}

--- a/community/docs/http_files/insurance.http
+++ b/community/docs/http_files/insurance.http
@@ -1,0 +1,42 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create insurance
+POST https://api.easypost.com/v2/insurances
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "insurance": {
+    "to_address": {
+      "id": "adr_123"
+    },
+    "from_address": {
+      "id": "adr_456"
+    },
+    "tracking_code": "9400110898825022579493",
+    "carrier": "USPS",
+    "reference": "insuranceRef1",
+    "amount": "100.00"
+  }
+}
+
+###
+
+# Retrieve an insurance entry
+GET https://api.easypost.com/v2/insurances/{{INSURANCE_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all insurance entries
+GET https://api.easypost.com/v2/insurances
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Refund an insurance entry
+POST https://api.easypost.com/v2/insurances/{{INSURANCE_ID}}/refund
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/orders.http
+++ b/community/docs/http_files/orders.http
@@ -1,0 +1,115 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create an Order with existing Shipments
+POST https://api.easypost.com/v2/orders
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "order": {
+    "to_address": {
+      "id": "adr_123"
+    },
+    "from_address": {
+      "id": "adr_456"
+    },
+    "shipments": [
+      {
+        "id": "shp_123"
+      },
+      {
+        "id": "shp_456"
+      }
+    ]
+  }
+}
+
+###
+
+# Create an Order with new Shipments
+POST https://api.easypost.com/v2/orders
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "order": {
+    "to_address": {
+      "id": "adr_123"
+    },
+    "from_address": {
+      "id": "adr_456"
+    },
+    "shipments": [
+      {
+        "parcel": {
+          "length": 8,
+          "width": 6,
+          "height": 5,
+          "weight": 10
+        }
+      },
+      {
+        "parcel": {
+          "length": 8,
+          "width": 6,
+          "height": 5,
+          "weight": 10
+        }
+      }
+    ]
+  }
+}
+
+###
+
+# One-call-buy an Order (create and buy in one API call)
+POST https://api.easypost.com/v2/orders
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "order": {
+    "to_address": {
+      "id": "adr_123"
+    },
+    "from_address": {
+      "id": "adr_456"
+    },
+    "shipments": [
+      {
+        "parcel": {
+          "weight": "10.2"
+        }
+      },
+      {
+        "parcel": {
+          "predefined_package": "FedExBox",
+          "weight": "17.5"
+        }
+      }
+    ],
+    "service": "NextDayAir",
+    "carrier_accounts": [
+      "ca_123"
+    ]
+  }
+}
+
+###
+
+# Buy an existing Order
+POST https://api.easypost.com/v2/orders/{{ORDER_ID}}/buy
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "carrier": "FedEx",
+  "service": "FEDEX_GROUND"
+}
+
+###
+
+# Retrieve an Order
+GET https://api.easypost.com/v2/orders/{{ORDER_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/parcels.http
+++ b/community/docs/http_files/parcels.http
@@ -1,0 +1,22 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a Parcel
+POST https://api.easypost.com/v2/parcels
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "parcel": {
+    "length": 10.2,
+    "width": 7.8,
+    "height": 4.3,
+    "weight": 21.2
+  }
+}
+
+###
+
+# Retrieve a Parcel
+GET https://api.easypost.com/v2/parcels/{{PARCEL_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/pickups.http
+++ b/community/docs/http_files/pickups.http
@@ -1,0 +1,53 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a Pickup
+POST https://api.easypost.com/v2/pickups
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "pickup": {
+    "reference": "my-first-pickup",
+    "min_datetime": "2022-10-01 10:30:00",
+    "max_datetime": "2022-10-02 10:30:00",
+    "shipment": "shp_123",
+    "address": "adr_123",
+    "is_account_address": "false",
+    "instructions": "Special pickup instructions"
+  }
+}
+
+###
+
+# Retrieve a Pickup
+GET https://api.easypost.com/v2/pickups/{{PICKUP_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all Pickups
+GET https://api.easypost.com/v2/pickups
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Buy a Pickup
+POST https://api.easypost.com/v2/pickups/{{PICKUP_ID}}/buy
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "carrier": "UPS",
+  "service": "Same-Day Pickup"
+}
+
+
+###
+
+# Cancel a Pickup
+POST https://api.easypost.com/v2/pickups/{{PICKUP_ID}}/cancel
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/rates.http
+++ b/community/docs/http_files/rates.http
@@ -1,0 +1,52 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Generate rates for a Shipment
+POST https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/rerate
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retrieve a Rate
+GET https://api.easypost.com/v2/rates/{{RATE_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Quote a Shipment (stateless/ephemeral rates) (beta)
+POST https://api.easypost.com/beta/rates
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipment": {
+    "to_address": {
+      "name": "Dr. Steve Brule",
+      "street1": "179 N Harbor Dr",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "zip": "90277",
+      "country": "US",
+      "phone": "8573875756",
+      "email": "dr_steve_brule@gmail.com"
+    },
+    "from_address": {
+      "name": "EasyPost",
+      "street1": "417 Montgomery Street",
+      "street2": "5th Floor",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94104",
+      "country": "US",
+      "phone": "4153334445",
+      "email": "support@easypost.com"
+    },
+    "parcel": {
+      "length": "20.2",
+      "width": "10.9",
+      "height": "5",
+      "weight": "65.0"
+    }
+  }
+}

--- a/community/docs/http_files/referral-customers.http
+++ b/community/docs/http_files/referral-customers.http
@@ -1,0 +1,88 @@
+@API_KEY = EASYPOST_API_KEY
+@REFERRAL_CUSTOMER_API_KEY = EASYPOST_REFERRAL_CUSTOMER_API_KEY
+
+# Create a referral customer
+POST https://api.easypost.com/v2/referral_customers
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "user": {
+    "name": "Firstname Lastname",
+    "email": "email@example.com",
+    "phone_number": "8888888888"
+  }
+}
+
+###
+
+# List all referral customers
+GET https://api.easypost.com/v2/referral_customers
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Update a referral customer
+PUT https://api.easypost.com/v2/referral_customers
+Authorization: Bearer {{REFERRAL_CUSTOMER_API_KEY}}
+Content-Type: application/json
+
+{
+  "user": {
+    "email": "new_email@example.com"
+  }
+}
+
+###
+
+# Add Stripe credit card to referral customer's account
+POST https://api.easypost.com/beta/referral_customers/payment_method
+Authorization: Bearer {{REFERRAL_CUSTOMER_API_KEY}}
+Content-Type: application/json
+
+{
+  "payment_method": {
+    "stripe_customer_id": "cus_123",
+    "payment_method_reference": "card_123",
+    "priority": "primary"
+  }
+}
+
+
+###
+
+# Add Stripe bank account to referral customer's account
+POST https://api.easypost.com/beta/referral_customers/payment_method
+Authorization: Bearer {{REFERRAL_CUSTOMER_API_KEY}}
+Content-Type: application/json
+
+{
+  "payment_method": {
+    "stripe_customer_id": "cus_123",
+    "payment_method_reference": "ba_123",
+    "priority": "primary"
+  }
+}
+
+###
+
+# Refund a referral customer's account by a specific amount ($20.00)
+POST https://api.easypost.com/v2/referral_customers/refund
+Authorization: Bearer {{REFERRAL_CUSTOMER_API_KEY}}
+Content-Type: application/json
+
+{
+  "refund_amount": 2000
+}
+
+###
+
+# Refund a referral customer's account by a payment log entry
+POST https://api.easypost.com/v2/referral_customers/refund
+Authorization: Bearer {{REFERRAL_CUSTOMER_API_KEY}}
+Content-Type: application/json
+
+{
+  "payment_log_id": "pl_123"
+}

--- a/community/docs/http_files/refunds.http
+++ b/community/docs/http_files/refunds.http
@@ -1,0 +1,30 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a Refund
+POST https://api.easypost.com/v2/refunds
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "refund": {
+    "carrier": "USPS",
+    "tracking_codes": [
+      "EZ1000000001"
+    ]
+  }
+}
+
+###
+
+# Retrieve a Refund
+GET https://api.easypost.com/v2/refunds/{{REFUND_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all Refunds
+GET https://api.easypost.com/v2/refunds
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/reports.http
+++ b/community/docs/http_files/reports.http
@@ -1,0 +1,26 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a payment log report
+POST https://api.easypost.com/v2/reports/payment_log
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "start_date": "2019-01-01",
+  "end_date": "2019-01-31"
+}
+
+###
+
+# Retrieve a report
+GET https://api.easypost.com/v2/reports/reports/{{REPORT_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all payment log reports
+GET https://api.easypost.com/v2/reports/payment_log
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/scanforms.http
+++ b/community/docs/http_files/scanforms.http
@@ -1,0 +1,32 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a ScanForm with existing Shipments
+POST https://api.easypost.com/v2/scan_forms
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipments": [
+    {
+      "id": "shp_123"
+    },
+    {
+      "id": "shp_456"
+    }
+  ]
+}
+
+###
+
+# Retrieve a ScanForm
+GET https://api.easypost.com/v2/scan_forms/{{SCAN_FORM_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all ScanForms
+GET https://api.easypost.com/v2/scan_forms
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/shipments.http
+++ b/community/docs/http_files/shipments.http
@@ -1,0 +1,279 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a Shipment
+POST https://api.easypost.com/v2/shipments
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipment": {
+    "to_address": {
+      "name": "Dr. Steve Brule",
+      "street1": "179 N Harbor Dr",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "zip": "90277",
+      "country": "US",
+      "phone": "8573875756",
+      "email": "dr_steve_brule@gmail.com"
+    },
+    "from_address": {
+      "name": "EasyPost",
+      "street1": "417 Montgomery Street",
+      "street2": "5th Floor",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94104",
+      "country": "US",
+      "phone": "4153334445",
+      "email": "support@easypost.com"
+    },
+    "parcel": {
+      "length": "20.2",
+      "width": "10.9",
+      "height": "5",
+      "weight": "65.9"
+    },
+    "customs_info": {
+      "id": "cstinfo_123"
+    }
+  }
+}
+
+###
+
+# Create a Shipment with existing Addresses and Parcel
+POST https://api.easypost.com/v2/shipments
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipment": {
+    "to_address": {
+      "id": "adr_123"
+    },
+    "from_address": {
+      "id": "adr_456"
+    },
+    "parcel": {
+      "id": "prcl_123"
+    },
+    "customs_info": {
+      "id": "cstinfo_123"
+    }
+  }
+}
+
+###
+
+# Create a Shipment with options
+POST https://api.easypost.com/v2/shipments
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipment": {
+    "to_address": {
+      "id": "adr_123"
+    },
+    "from_address": {
+      "id": "adr_456"
+    },
+    "parcel": {
+      "id": "prcl_123"
+    },
+    "options": {
+      "print_custom_1": "Custom label message"
+    }
+  }
+}
+
+###
+
+# Create a Shipment with tax identifiers
+POST https://api.easypost.com/v2/shipments
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipment": {
+    "to_address": {
+      "id": "adr_123"
+    },
+    "from_address": {
+      "id": "adr_456"
+    },
+    "parcel": {
+      "id": "prcl_123"
+    },
+    "tax_identifiers": [
+      {
+        "entity": "SENDER",
+        "tax_id": "GB123456789",
+        "tax_id_type": "EORI",
+        "issuing_country": "GB"
+      }
+    ]
+  }
+}
+
+###
+
+# One-call-buy a Shipment (create and buy in one API call)
+POST https://api.easypost.com/v2/shipments
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipment": {
+    "to_address": {
+      "name": "Dr. Steve Brule",
+      "street1": "179 N Harbor Dr",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "zip": "90277",
+      "country": "US",
+      "phone": "8573875756",
+      "email": "dr_steve_brule@gmail.com"
+    },
+    "from_address": {
+      "name": "EasyPost",
+      "street1": "417 Montgomery Street",
+      "street2": "5th Floor",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94104",
+      "country": "US",
+      "phone": "4153334445",
+      "email": "support@easypost.com"
+    },
+    "parcel": {
+      "length": "20.2",
+      "width": "10.9",
+      "height": "5",
+      "weight": "65.9"
+    },
+    "service": "NextDayAir",
+    "carrier_accounts": [
+      "ca_123"
+    ]
+  }
+}
+
+###
+
+# Retrieve a Shipment
+GET https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all Shipments
+GET https://api.easypost.com/v2/shipments
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Purchase a Shipment
+POST https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/buy
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "rate": {
+    "id": "rate_123"
+  },
+  "insurance": "100.00"
+}
+
+###
+
+# Insure a already-purchased Shipment
+POST https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/insure
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "amount": "200"
+}
+
+###
+
+# Refund a Shipment
+POST https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/refund
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Generate label for a Shipment
+GET https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/label
+    ?file_format=ZPL
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Create a return Shipment
+POST https://api.easypost.com/v2/shipments
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "shipment": {
+    "to_address": {
+      "name": "Dr. Steve Brule",
+      "street1": "179 N Harbor Dr",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "zip": "90277",
+      "country": "US",
+      "phone": "8573875756",
+      "email": "dr_steve_brule@gmail.com"
+    },
+    "from_address": {
+      "name": "EasyPost",
+      "street1": "417 Montgomery Street",
+      "street2": "5th Floor",
+      "city": "San Francisco",
+      "state": "CA",
+      "zip": "94104",
+      "country": "US",
+      "phone": "4153334445",
+      "email": "support@easypost.com"
+    },
+    "parcel": {
+      "length": "20.2",
+      "width": "10.9",
+      "height": "5",
+      "weight": "65.9"
+    },
+    "is_return": true
+  }
+}
+
+###
+
+# Create a return packing slip for a Shipment
+POST https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/forms
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "form": {
+    "type": "return_packing_slip",
+    "barcode": "RMA12345678900",
+    "line_items": [
+      {
+        "product": {
+          "title": "Square Reader",
+          "barcode": "855658003251"
+        },
+        "units": 8
+      }
+    ]
+  }
+}

--- a/community/docs/http_files/smartrate.http
+++ b/community/docs/http_files/smartrate.http
@@ -1,0 +1,14 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Retrieve time in transit information for an existing Shipment
+GET https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/smartrate
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retrieve estimated delivery date for an existing Shipment
+GET https://api.easypost.com/v2/shipments/{{SHIPMENT_ID}}/smartrate/delivery_dates
+    ?planned_ship_date=2021-06-01
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/trackers.http
+++ b/community/docs/http_files/trackers.http
@@ -1,0 +1,29 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a Tracker
+POST https://api.easypost.com/v2/trackers
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "tracker": {
+    "tracking_code": "EZ1000000001",
+    "carrier": "USPS"
+  }
+}
+
+###
+
+# Retrieve a Tracker
+GET https://api.easypost.com/v2/trackers/{{TRACKER_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all Trackers
+GET https://api.easypost.com/v2/trackers
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+

--- a/community/docs/http_files/users.http
+++ b/community/docs/http_files/users.http
@@ -1,0 +1,67 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Retrieve the authenticated user
+GET https://api.easypost.com/v2/users
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Update the authenticated user
+PATCH https://api.easypost.com/v2/users
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "user": {
+    "recharge_threshold": "50.00"
+  }
+}
+
+###
+
+# Create a child user
+POST https://api.easypost.com/v2/users
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "user": {
+    "name": "Child User"
+  }
+}
+
+###
+
+# Retrieve a child user
+GET https://api.easypost.com/v2/users/{{CHILD_USER_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all child users
+GET https://api.easypost.com/v2/users/children
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Update a child user
+PATCH https://api.easypost.com/v2/users/{{CHILD_USER_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "user": {
+    "name": "New Name"
+  }
+}
+
+###
+
+# Delete a child user
+DELETE https://api.easypost.com/v2/users/{{CHILD_USER_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json

--- a/community/docs/http_files/webhooks.http
+++ b/community/docs/http_files/webhooks.http
@@ -1,0 +1,69 @@
+@API_KEY = EASYPOST_API_KEY
+
+# Create a webhook
+POST https://api.easypost.com/v2/webhooks
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+{
+  "webhook": {
+    "url": "example.com"
+  }
+}
+
+###
+
+# Retrieve a webhook
+GET https://api.easypost.com/v2/webhooks/{{WEBHOOK_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all webhooks
+GET https://api.easypost.com/v2/webhooks
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Update a webhook (enable or disable)
+PATCH https://api.easypost.com/v2/webhooks/{{WEBHOOK_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Delete a webhook
+DELETE https://api.easypost.com/v2/webhooks/{{WEBHOOK_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retrieve a webhook event
+GET https://api.easypost.com/v2/events/{{EVENT_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all webhook events
+GET https://api.easypost.com/v2/events
+    ?page_size=10
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# Retrieve the payload of a webhook event
+GET https://api.easypost.com/v2/events/{{EVENT_ID}}/payloads/{{PAYLOAD_ID}}
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json
+
+###
+
+# List all payloads of a webhook event
+GET https://api.easypost.com/v2/events/{{EVENT_ID}}/payloads
+Authorization: Bearer {{API_KEY}}
+Content-Type: application/json


### PR DESCRIPTION
Adds `.http` files for HTTP snippets for each endpoint of the API and example calls.

Developers can use these files in tandem with the [REST Client plugin](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) in VSCode or the [HTTP Client plugin](https://www.jetbrains.com/help/idea/2023.3/http-client-in-product-code-editor.html) in JetBrains IDEs, where they can be run one-off, chained as request-response pairs, or exported as cURL requests or other supported languages.

This is placed in the "community" section, as it is not officially supported or maintained by EasyPost.