### PR TITLE
fix: fundWallet reference for Node docs

### DIFF
--- a/official/docs/node/current/billing/fund.js
+++ b/official/docs/node/current/billing/fund.js
@@ -3,5 +3,5 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  await client.Billing.fund('2000', 'primary');
+  await client.Billing.fundWallet('2000', 'primary');
 })();

--- a/official/docs/node/v5/billing/fund.js
+++ b/official/docs/node/v5/billing/fund.js
@@ -2,4 +2,4 @@ const Easypost = require('@easypost/api');
 
 const api = new Easypost('EASYPOST_API_KEY');
 
-api.Billing.fund('2000', 'primary').then(console.log);
+api.Billing.fundWallet('2000', 'primary').then(console.log);

--- a/official/docs/node/v6/billing/fund.js
+++ b/official/docs/node/v6/billing/fund.js
@@ -3,5 +3,5 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  await client.Billing.fund('2000', 'primary');
+  await client.Billing.fundWallet('2000', 'primary');
 })();


### PR DESCRIPTION
The node examples have the incorrect `fund` reference that was changed prior to release to `fundWallet`. This fixes those.