### PR TITLE
fix: curl quoting of URLs

### DIFF
--- a/official/docs/curl/current/addresses/list.sh
+++ b/official/docs/curl/current/addresses/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/addresses?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/addresses?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/batches/list.sh
+++ b/official/docs/curl/current/batches/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/batches?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/batches?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/billing/create-ep-credit-card.sh
+++ b/official/docs/curl/current/billing/create-ep-credit-card.sh
@@ -1,4 +1,4 @@
-curl -X POST "https://api.easypost.com/v2/credit_cards" \
+curl -X POST https://api.easypost.com/v2/credit_cards \
   -u "$REFERRAL_USER_API_KEY": \
   -H "Content-Type: application/json" \
   -d '{

--- a/official/docs/curl/current/billing/create-referral-token.sh
+++ b/official/docs/curl/current/billing/create-referral-token.sh
@@ -1,2 +1,2 @@
-curl -X GET "https://api.easypost.com/v2/partners/stripe_public_key" \
+curl -X GET https://api.easypost.com/v2/partners/stripe_public_key \
   -u "$PARTNER_API_KEY":

--- a/official/docs/curl/current/child-users/list.sh
+++ b/official/docs/curl/current/child-users/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/users/children?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/users/children?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/endshipper/list.sh
+++ b/official/docs/curl/current/endshipper/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/end_shippers?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/end_shippers?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/events/list.sh
+++ b/official/docs/curl/current/events/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/events?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/events?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/insurance/list.sh
+++ b/official/docs/curl/current/insurance/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/insurances?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/insurances?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/pagination/get-next-page.sh
+++ b/official/docs/curl/current/pagination/get-next-page.sh
@@ -1,7 +1,7 @@
 # Get first page of results
-curl -X 'GET https://api.easypost.com/v2/shipments?page_size=5' \
+curl -X GET "https://api.easypost.com/v2/shipments?page_size=5" \
   -u "EASYPOST_API_KEY":
 
 # Provide the ID of the last element of the previous page in the before_id param
-curl -X 'GET https://api.easypost.com/v2/shipments?page_size=5&before_id=shp_...' \
+curl -X GET "https://api.easypost.com/v2/shipments?page_size=5&before_id=shp_..." \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/pickups/list.sh
+++ b/official/docs/curl/current/pickups/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/pickups?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/pickups?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/rates/retrieve-stateless.sh
+++ b/official/docs/curl/current/rates/retrieve-stateless.sh
@@ -1,4 +1,4 @@
-$ curl -X POST "https://api.easypost.com/beta/rates" \
+$ curl -X POST https://api.easypost.com/beta/rates \
   -u "EASYPOST_API_KEY": \
   -H "Content-Type: application/json" \
   -d '{

--- a/official/docs/curl/current/referral-customers/add-payment-method-with-bank-account.sh
+++ b/official/docs/curl/current/referral-customers/add-payment-method-with-bank-account.sh
@@ -1,4 +1,4 @@
-curl -X POST "https://api.easypost.com/beta/referral_customers/payment_method" \
+curl -X POST https://api.easypost.com/beta/referral_customers/payment_method \
   -u "$REFERRAL_USER_API_KEY": \
   -H "Content-Type: application/json" \
   -d '{

--- a/official/docs/curl/current/referral-customers/add-payment-method-with-credit-card.sh
+++ b/official/docs/curl/current/referral-customers/add-payment-method-with-credit-card.sh
@@ -1,4 +1,4 @@
-curl -X POST "https://api.easypost.com/beta/referral_customers/payment_method" \
+curl -X POST https://api.easypost.com/beta/referral_customers/payment_method \
   -u "$REFERRAL_USER_API_KEY": \
   -H "Content-Type: application/json" \
   -d '{

--- a/official/docs/curl/current/referral-customers/create.sh
+++ b/official/docs/curl/current/referral-customers/create.sh
@@ -1,4 +1,4 @@
-curl -X POST "https://api.easypost.com/v2/referral_customers" \
+curl -X POST https://api.easypost.com/v2/referral_customers \
   -u "$PARTNER_API_KEY": \
   -H "Content-Type: application/json" \
   -d '{

--- a/official/docs/curl/current/referral-customers/list.sh
+++ b/official/docs/curl/current/referral-customers/list.sh
@@ -1,2 +1,2 @@
-curl -X GET "https://api.easypost.com/v2/referral_customers" \
+curl -X GET https://api.easypost.com/v2/referral_customers \
   -u "$PARTNER_API_KEY":

--- a/official/docs/curl/current/referral-customers/refund-by-amount.sh
+++ b/official/docs/curl/current/referral-customers/refund-by-amount.sh
@@ -1,4 +1,4 @@
-curl -x POST "https://api.easypost.com/beta/referral_customers/refunds" \
+curl -x POST https://api.easypost.com/beta/referral_customers/refunds \
   -u "$REFERRAL_USER_API_KEY": \
   -H 'Content-Type: application/json' \
   -d '{

--- a/official/docs/curl/current/referral-customers/refund-by-payment-log.sh
+++ b/official/docs/curl/current/referral-customers/refund-by-payment-log.sh
@@ -1,4 +1,4 @@
-curl -x POST "https://api.easypost.com/beta/referral_customers/refunds" \
+curl -x POST https://api.easypost.com/beta/referral_customers/refunds \
   -u "$REFERRAL_USER_API_KEY": \
   -H 'Content-Type: application/json' \
   -d '{

--- a/official/docs/curl/current/referral-customers/update.sh
+++ b/official/docs/curl/current/referral-customers/update.sh
@@ -1,4 +1,4 @@
-curl -X PUT "https://api.easypost.com/v2/referral_customers" \
+curl -X PUT https://api.easypost.com/v2/referral_customers \
   -u "$REFERRAL_USER_API_KEY": \
   -H "Content-Type: application/json" \
   -d '{

--- a/official/docs/curl/current/refunds/list.sh
+++ b/official/docs/curl/current/refunds/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/refunds?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/refunds?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/reports/list.sh
+++ b/official/docs/curl/current/reports/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/reports/payment_log?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/reports/payment_log?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/scan-form/list.sh
+++ b/official/docs/curl/current/scan-form/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/scan_forms?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/scan_forms?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/shipments/list.sh
+++ b/official/docs/curl/current/shipments/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/shipments?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/shipments?page_size=5" \
   -u "EASYPOST_API_KEY":

--- a/official/docs/curl/current/trackers/list.sh
+++ b/official/docs/curl/current/trackers/list.sh
@@ -1,2 +1,2 @@
-curl -X GET https://api.easypost.com/v2/trackers?page_size=5 \
+curl -X GET "https://api.easypost.com/v2/trackers?page_size=5" \
   -u "EASYPOST_API_KEY":


### PR DESCRIPTION
Found various inconsistencies of quoting in our curl URLs, they should only be quoted when we have URL params
