### PR TITLE
chore: remove unnecessary retrieve calls

### DIFF
--- a/official/docs/csharp/current/addresses/verify.cs
+++ b/official/docs/csharp/current/addresses/verify.cs
@@ -14,21 +14,7 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Parameters.Address.Create parameters = new()
-            {
-                Street1 = "417 MONTGOMERY ST",
-                Street2 = "FLOOR 5",
-                City = "SAN FRANCISCO",
-                State = "CA",
-                Zip = "94104",
-                Country = "US",
-                Company = "EasyPost",
-                Phone = "415-123-4567",
-            };
-
-            Address address = await client.Address.Create(parameters);
-
-            address = await client.Address.Verify(address.Id)
+            address = await client.Address.Verify("adr_...")
 
             Console.WriteLine(JsonConvert.SerializeObject(address, Formatting.Indented));
         }

--- a/official/docs/csharp/current/batches/add-shipments.cs
+++ b/official/docs/csharp/current/batches/add-shipments.cs
@@ -16,14 +16,12 @@ namespace EasyPostExamples
 
             Shipment shipment = await client.Shipment.Retrieve("shp_...");
 
-            Batch batch = await client.Batch.Retrieve("batch_...");
-
             Parameters.Batch.AddShipments parameters = new()
             {
                 Shipments = new List<IShipmentParameter> { shipment },
             };
 
-            batch = await client.Batch.AddShipments(batch.Id, parameters);
+            batch = await client.Batch.AddShipments("batch_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(batch, Formatting.Indented));
         }

--- a/official/docs/csharp/current/batches/buy.cs
+++ b/official/docs/csharp/current/batches/buy.cs
@@ -13,9 +13,7 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Batch batch = await client.Batch.Retrieve("batch_...");
-
-            batch = await client.Batch.Buy(batch.Id);
+            batch = await client.Batch.Buy("batch_...");
 
             Console.WriteLine(JsonConvert.SerializeObject(batch, Formatting.Indented));
         }

--- a/official/docs/csharp/current/batches/buy.cs
+++ b/official/docs/csharp/current/batches/buy.cs
@@ -13,7 +13,36 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            batch = await client.Batch.Buy("batch_...");
+            Parameters.Shipment.Create shipmentParameters = new()
+            {
+                ToAddress = new Parameters.Address.Create
+                {
+                    Id = "adr_..."
+                },
+                FromAddress = new Parameters.Address.Create
+                {
+                    Id = "adr_..."
+                },
+                Parcel = new Parameters.Parcel.Create
+                {
+                    Id = "prcl_..."
+                },
+                Service = "First",
+                Carrier = "USPS",
+                CarrierAccountIds = new List<string> { "ca_..." }
+            };
+
+            Parameters.Batch.Create parameters = new()
+            {
+                Shipments = new List<IShipmentParameter>()
+                {
+                    shipmentParameters
+                }
+            };
+
+            Batch batch = await client.Batch.Create(parameters);
+
+            batch = await client.Batch.Buy(batch.Id);
 
             Console.WriteLine(JsonConvert.SerializeObject(batch, Formatting.Indented));
         }

--- a/official/docs/csharp/current/batches/label.cs
+++ b/official/docs/csharp/current/batches/label.cs
@@ -14,14 +14,12 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Batch batch = await client.Batch.Retrieve("batch_...");
-
             Parameters.Batch.GenerateLabel parameters = new()
             {
                 FileFormat = "PDF",
             }
 
-            batch = await client.Batch.GenerateLabel(batch.Id, parameters);
+            batch = await client.Batch.GenerateLabel("batch_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(batch, Formatting.Indented));
         }

--- a/official/docs/csharp/current/batches/remove-shipments.cs
+++ b/official/docs/csharp/current/batches/remove-shipments.cs
@@ -16,14 +16,12 @@ namespace EasyPostExamples
 
             Shipment shipment = await client.Shipment.Retrieve("shp_...");
 
-            Batch batch = await client.Batch.Retrieve("batch_...");
-
             Parameters.Batch.RemoveShipments parameters = new()
             {
                 Shipments = new List<IShipmentParameter> { shipment },
             };
 
-            batch = await client.Batch.RemoveShipments(batch.Id, parameters);
+            batch = await client.Batch.RemoveShipments("batch_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(batch, Formatting.Indented));
         }

--- a/official/docs/csharp/current/batches/scan-forms.cs
+++ b/official/docs/csharp/current/batches/scan-forms.cs
@@ -14,14 +14,12 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Batch batch = await client.Batch.Retrieve("batch_...");
-
             Parameters.Batch.GenerateScanForm parameters = new()
             {
                 FileFormat = "ZPL",
             }
 
-            batch = await client.Batch.GenerateScanForm(batch.Id, parameters);
+            batch = await client.Batch.GenerateScanForm("batch_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(batch, Formatting.Indented));
         }

--- a/official/docs/csharp/current/brand/update.cs
+++ b/official/docs/csharp/current/brand/update.cs
@@ -14,8 +14,6 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            User user = await client.User.RetrieveMe();
-
             Parameters.User.UpdateBrand parameters = new()
             {
                 BackgroundColorHexCode = "#FFFFFF",
@@ -27,7 +25,7 @@ namespace EasyPostExamples
                 Theme = "theme1"
             };
 
-            Brand brand = await client.User.UpdateBrand(user.Id, parameters);
+            Brand brand = await client.User.UpdateBrand("user_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(user, Formatting.Indented));
         }

--- a/official/docs/csharp/current/carrier-accounts/delete.cs
+++ b/official/docs/csharp/current/carrier-accounts/delete.cs
@@ -13,8 +13,6 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            CarrierAccount carrierAccount = await client.CarrierAccount.Retrieve("ca_...");
-
-            await client.CarrierAccount.Delete(carrierAccount.Id);
+            await client.CarrierAccount.Delete("ca_...");
         }
     }

--- a/official/docs/csharp/current/carrier-accounts/update.cs
+++ b/official/docs/csharp/current/carrier-accounts/update.cs
@@ -14,8 +14,6 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            CarrierAccount carrierAccount = await client.CarrierAccount.Retrieve("ca_...");
-
             Parameters.CarrierAccount.Update parameters = new()
             {
                 Description = "FL Location DHL eCommerce Solutions Account",
@@ -25,7 +23,7 @@ namespace EasyPostExamples
                 },
             };
 
-            carrierAccount = await client.CarrierAccount.Update(carrierAccount.Id, parameters);
+            carrierAccount = await client.CarrierAccount.Update("ca_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(carrierAccount, Formatting.Indented));
         }

--- a/official/docs/csharp/current/carrier-metadata/retrieve.cs
+++ b/official/docs/csharp/current/carrier-metadata/retrieve.cs
@@ -16,7 +16,6 @@ namespace EasyPostExamples
 
             // Request all metadata for all carriers
             List<Carrier> carrierMetadata = await client.CarrierMetadata.Retrieve();
-
             Console.WriteLine(JsonConvert.SerializeObject(carrierMetadata, Formatting.Indented));
 
             // Request specific metadata for specific carriers
@@ -27,7 +26,6 @@ namespace EasyPostExamples
             };
 
             List<Carrier> carrierMetadata = await client.CarrierMetadata.Retrieve(parameters);
-
             Console.WriteLine(JsonConvert.SerializeObject(carrierMetadata, Formatting.Indented));
         }
     }

--- a/official/docs/csharp/current/child-users/delete.cs
+++ b/official/docs/csharp/current/child-users/delete.cs
@@ -13,8 +13,6 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            User user = await client.User.Retrieve("user_...");
-
-            await client.User.Delete(user.Id);
+            await client.User.Delete("user_...");
         }
     }

--- a/official/docs/csharp/current/endshipper/buy.cs
+++ b/official/docs/csharp/current/endshipper/buy.cs
@@ -14,16 +14,16 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
+            Shipment retrievedShipment = await client.Shipment.Retrieve("shp_...");
 
-            Rate rate = shipment.LowestRate();
+            Rate rate = retrievedShipment.LowestRate();
 
             Parameters.Shipment.Buy parameters = new(rate)
             {
                 EndShipperId = "es_...",
             };
 
-            shipment = await client.Shipment.Buy(shipment.Id, parameters);
+            shipment = await client.Shipment.Buy(retrievedShipment.Id, parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(shipment, Formatting.Indented));
         }

--- a/official/docs/csharp/current/endshipper/update.cs
+++ b/official/docs/csharp/current/endshipper/update.cs
@@ -14,8 +14,6 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            EndShipper endShipper = await client.EndShipper.Retrieve("es_...");
-
             // Updating an EndShipper requires all the original data to be sent back + the updated data
             Parameters.EndShipper.Update parameters = new()
             {
@@ -31,7 +29,7 @@ namespace EasyPostExamples
                 Email = "FOO@EXAMPLE.COM",
             };
 
-            endShipper = await client.EndShipper.Update(endShipper.Id, parameters);
+            endShipper = await client.EndShipper.Update("es_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(endShipper, Formatting.Indented));
         }

--- a/official/docs/csharp/current/forms/create.cs
+++ b/official/docs/csharp/current/forms/create.cs
@@ -14,9 +14,6 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            // Shipment has to be purchased before forms can be generated
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
-
             Parameters.Shipment.GenerateForm parameters = new()
             {
                 Type = "return_packing_slip",
@@ -39,7 +36,7 @@ namespace EasyPostExamples
                 }
             };
 
-            shipment = await client.Shipment.GenerateForm(shipment.Id, parameters);
+            shipment = await client.Shipment.GenerateForm("shp_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(shipment, Formatting.Indented));
         }

--- a/official/docs/csharp/current/orders/buy.cs
+++ b/official/docs/csharp/current/orders/buy.cs
@@ -14,11 +14,9 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Order order = await client.Order.Retrieve("order_...");
-
             Parameters.Order.Buy parameters = new("FedEx", "FEDEX_GROUND");
 
-            order = await client.Order.Buy(order.Id, parameters);
+            order = await client.Order.Buy("order_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(order, Formatting.Indented));
         }

--- a/official/docs/csharp/current/pickups/buy.cs
+++ b/official/docs/csharp/current/pickups/buy.cs
@@ -14,11 +14,9 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Pickup pickup = await client.Pickup.Retrieve("pickup_...");
-
             Parameters.Pickup.Buy parameters = new("UPS", "Same-Day Pickup");
 
-            pickup = await client.Pickup.Buy(pickup.Id, parameters);
+            pickup = await client.Pickup.Buy("pickup_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(pickup, Formatting.Indented));
         }

--- a/official/docs/csharp/current/pickups/cancel.cs
+++ b/official/docs/csharp/current/pickups/cancel.cs
@@ -13,9 +13,7 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Pickup pickup = await client.Pickup.Retrieve("pickup_...");
-
-            pickup = await client.Pickup.Cancel(pickup.Id);
+            pickup = await client.Pickup.Cancel("pickup_...");
 
             Console.WriteLine(JsonConvert.SerializeObject(pickup, Formatting.Indented));
         }

--- a/official/docs/csharp/current/rates/regenerate.cs
+++ b/official/docs/csharp/current/rates/regenerate.cs
@@ -14,9 +14,7 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
-
-            shipment = await client.Shipment.RegenerateRates(shipment.Id);
+            shipment = await client.Shipment.RegenerateRates("shp_...");
 
             Console.WriteLine(JsonConvert.SerializeObject(shipment, Formatting.Indented));
         }

--- a/official/docs/csharp/current/shipments/buy.cs
+++ b/official/docs/csharp/current/shipments/buy.cs
@@ -14,13 +14,13 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
+            Shipment retrievedShipment = await client.Shipment.Retrieve("shp_...");
 
-            Rate rate = shipment.LowestRate();
+            Rate rate = retrievedShipment.LowestRate();
 
             Parameters.Shipment.Buy parameters = new(rate);
 
-            shipment = await client.Shipment.Buy(shipment.Id, parameters);
+            shipment = await client.Shipment.Buy(retrievedShipment.Id, parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(shipment, Formatting.Indented));
         }

--- a/official/docs/csharp/current/shipments/label.cs
+++ b/official/docs/csharp/current/shipments/label.cs
@@ -14,14 +14,12 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
-
             Parameters.Shipment.GenerateLabel parameters = new()
             {
                 FileFormat = "ZPL",
             };
 
-            shipment = await client.Shipment.GenerateLabel(shipment.Id, parameters);
+            shipment = await client.Shipment.GenerateLabel("shp_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(shipment, Formatting.Indented));
         }

--- a/official/docs/csharp/current/shipping-insurance/insure.cs
+++ b/official/docs/csharp/current/shipping-insurance/insure.cs
@@ -13,9 +13,7 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
-
-            shipment = await client.Shipment.Insure(shipment.Id, 200);
+            shipment = await client.Shipment.Insure("shp_...", 200);
 
             Console.WriteLine(JsonConvert.SerializeObject(shipment, Formatting.Indented));
         }

--- a/official/docs/csharp/current/shipping-refund/refund.cs
+++ b/official/docs/csharp/current/shipping-refund/refund.cs
@@ -13,9 +13,7 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
-
-            shipment = await client.Shipment.Refund(shipment.Id);
+            shipment = await client.Shipment.Refund("shp_...");
 
             Console.WriteLine(JsonConvert.SerializeObject(shipment, Formatting.Indented));
         }

--- a/official/docs/csharp/current/smartrate/retrieve-estimated-delivery-date.cs
+++ b/official/docs/csharp/current/smartrate/retrieve-estimated-delivery-date.cs
@@ -14,14 +14,12 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
-
             Parameters.Shipment.RetrieveEstimatedDeliveryDate parameters = new()
             {
                 PlannedShipDate = "2021-01-01",
             };
 
-            List<RateWithEstimatedDeliveryDate> rates = await client.Shipment.RetrieveEstimatedDeliveryDate(shipment.Id, parameters);
+            List<RateWithEstimatedDeliveryDate> rates = await client.Shipment.RetrieveEstimatedDeliveryDate("shp_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(rates, Formatting.Indented));
         }

--- a/official/docs/csharp/current/smartrate/retrieve-time-in-transit-statistics.cs
+++ b/official/docs/csharp/current/smartrate/retrieve-time-in-transit-statistics.cs
@@ -13,9 +13,7 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Shipment shipment = await client.Shipment.Retrieve("shp_...");
-
-            List<SmartRate> smartRates = await client.Shipment.GetSmartRates(shipment.Id);
+            List<SmartRate> smartRates = await client.Shipment.GetSmartRates("shp_...");
 
             Console.WriteLine(JsonConvert.SerializeObject(smartRates, Formatting.Indented));
         }

--- a/official/docs/csharp/current/users/update.cs
+++ b/official/docs/csharp/current/users/update.cs
@@ -14,14 +14,12 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            User user = await client.User.RetrieveMe();
-
             Parameters.User.Update parameters = new()
             {
                 RechargeThreshold = "50.00"
             };
 
-            user = await client.User.Update(user.Id, parameters);
+            user = await client.User.Update("user_...", parameters);
 
             Console.WriteLine(JsonConvert.SerializeObject(user, Formatting.Indented));
         }

--- a/official/docs/csharp/current/webhooks/delete.cs
+++ b/official/docs/csharp/current/webhooks/delete.cs
@@ -13,8 +13,6 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Webhook webhook = await client.Webhook.Retrieve("hook_...");
-
-            await client.Webhook.Delete(webhook.Id);
+            await client.Webhook.Delete("hook_...");
         }
     }

--- a/official/docs/csharp/current/webhooks/update.cs
+++ b/official/docs/csharp/current/webhooks/update.cs
@@ -14,20 +14,7 @@ namespace EasyPostExamples
         {
             var client = new EasyPost.Client(new EasyPost.ClientConfiguration("EASYPOST_API_KEY"));
 
-            Webhook webhook = await client.Webhook.Retrieve("hook_...");
-
-            // Update the webhook's settings
-            Parameters.Webhook.Update parameters = new()
-            {
-                Url = "https://example.com/webhook",
-            };
-
-            webhook = await client.Webhook.Update(webhook.Id, parameters);
-
-            // Sending an empty parameter set will simply enable a disabled webhook
-            parameters = new();
-
-            webhook = await client.Webhook.Update(webhook.Id, parameters);
+            webhook = await client.Webhook.Update("hook_...");
 
             Console.WriteLine(JsonConvert.SerializeObject(webhook, Formatting.Indented));
         }

--- a/official/docs/golang/current/addresses/verify.go
+++ b/official/docs/golang/current/addresses/verify.go
@@ -9,21 +9,7 @@ import (
 func main() {
 	client := easypost.New("EASYPOST_API_KEY")
 
-	address, _ := client.CreateAddress(
-		&easypost.Address{
-			Street1: "417 MONTGOMERY ST",
-			Street2: "FLOOR 5",
-			City:    "SAN FRANCISCO",
-			State:   "CA",
-			Zip:     "94104",
-			Country: "US",
-			Company: "EasyPost",
-			Phone:   "415-123-4567",
-		},
-		&easypost.CreateAddressOptions{},
-	)
+	address, _ := client.VerifyAddress("adr_...")
 
-	verifiedAddress, _ := client.VerifyAddress(address.ID)
-
-	fmt.Println(verifiedAddress)
+	fmt.Println(address)
 }

--- a/official/docs/golang/current/batches/add-shipments.go
+++ b/official/docs/golang/current/batches/add-shipments.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	client := easypost.New("EASYPOST_API_KEY")
 
-	shipment, _ := client.GetShipment()
+	shipment, _ := client.GetShipment("shp_...")
 
 	batch, _ := client.AddShipmentsToBatch("batch_...", shipment)
 

--- a/official/docs/golang/current/batches/add-shipments.go
+++ b/official/docs/golang/current/batches/add-shipments.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	client := easypost.New("EASYPOST_API_KEY")
 
-	shipment, _ := client.GetShipment("shp_...")
+	shipment, _ := client.GetShipment()
 
 	batch, _ := client.AddShipmentsToBatch("batch_...", shipment)
 

--- a/official/docs/golang/current/batches/buy.go
+++ b/official/docs/golang/current/batches/buy.go
@@ -9,7 +9,24 @@ import (
 func main() {
 	client := easypost.New("EASYPOST_API_KEY")
 
-	batch, _ := client.BuyBatch("batch_...")
+	createdBatch, _ := client.CreateBatch(
+		&easypost.Shipment{
+			FromAddress: &easypost.Address{
+				ID: "adr_...",
+			},
+			ToAddress: &easypost.Address{
+				ID: "adr_...",
+			},
+			Parcel: &easypost.Parcel{
+				ID: "prcl_...",
+			},
+			Service:           "First",
+			Carrier:           "USPS",
+			CarrierAccountIDs: []string{"ca_..."},
+		},
+	)
+
+	batch, _ := client.BuyBatch(createdBatch.ID)
 
 	fmt.Println(batch)
 }

--- a/official/docs/golang/current/brand/update.go
+++ b/official/docs/golang/current/brand/update.go
@@ -9,12 +9,11 @@ import (
 func main() {
 	client := easypost.New("EASYPOST_API_KEY")
 
-	user, _ := client.RetrieveMe()
 	brand, _ := client.UpdateBrand(
 		map[string]interface{}{
 			"color": "#303F9F",
 		},
-		user.ID,
+		"user_...",
 	)
 
 	fmt.Println(brand)

--- a/official/docs/golang/current/carrier-accounts/update.go
+++ b/official/docs/golang/current/carrier-accounts/update.go
@@ -9,11 +9,9 @@ import (
 func main() {
 	client := easypost.New("EASYPOST_API_KEY")
 
-	carrierAccount, _ := client.GetCarrierAccount("ca_...")
-
 	carrierAccount, _ = client.UpdateCarrierAccount(
 		&easypost.CarrierAccount{
-			ID:          carrierAccount.ID,
+			ID:          "ca_...",
 			Description: "FL Location DHL eCommerce Solutions Account",
 			Credentials: map[string]string{
 				"pickup_id": "abc123",

--- a/official/docs/golang/current/smartrate/retrieve-estimated-delivery-date.go
+++ b/official/docs/golang/current/smartrate/retrieve-estimated-delivery-date.go
@@ -9,8 +9,7 @@ import (
 func main() {
 	client := easypost.New("EASYPOST_API_KEY")
 
-	shipment, _ := client.GetShipment("shp_...")
-	estimatedDeliveryDates, _ := client.GetShipmentEstimatedDeliveryDate(shipment.ID, "YYYY-MM-DD")
+	estimatedDeliveryDates, _ := client.GetShipmentEstimatedDeliveryDate("shp_...", "YYYY-MM-DD")
 
 	fmt.Println(estimatedDeliveryDates)
 }

--- a/official/docs/golang/current/users/update.go
+++ b/official/docs/golang/current/users/update.go
@@ -11,7 +11,7 @@ func main() {
 
 	user, _ = client.UpdateUser(
 		&easypost.UserOptions{
-            ID: "user_..."
+			ID:             "user_...",
 			RechargeAmount: "50.00",
 		},
 	)

--- a/official/docs/golang/current/users/update.go
+++ b/official/docs/golang/current/users/update.go
@@ -9,12 +9,10 @@ import (
 func main() {
 	client := easypost.New("EASYPOST_API_KEY")
 
-	user, _ := client.RetrieveMe()
-	rechargeThreshold := "50.00"
-
 	user, _ = client.UpdateUser(
 		&easypost.UserOptions{
-			RechargeAmount: &rechargeThreshold,
+            ID: "user_..."
+			RechargeAmount: "50.00",
 		},
 	)
 

--- a/official/docs/java/current/addresses/verify.java
+++ b/official/docs/java/current/addresses/verify.java
@@ -10,21 +10,8 @@ public class Verify {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient("EASYPOST_API_KEY");
 
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        Address address = client.address.verify("adr_...");
 
-        params.put("street1", "417 Montgomery Street");
-        params.put("city", "SF");
-        params.put("state", "CA");
-        params.put("zip", "94104");
-        params.put("country", "US");
-        params.put("company", "EasyPost");
-        params.put("phone", "415-123-4567");
-        params.put("verify_strict", true);
-
-        Address address = client.address.create(params);
-
-        Address verifiedAddress = client.address.verify(address.getId());
-
-        System.out.println(verifiedAddress);
+        System.out.println(address);
     }
 }

--- a/official/docs/java/current/addresses/verify.java
+++ b/official/docs/java/current/addresses/verify.java
@@ -4,8 +4,6 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.model.Address;
 import com.easypost.service.EasyPostClient;
 
-import java.util.HashMap;
-
 public class Verify {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient("EASYPOST_API_KEY");

--- a/official/docs/java/current/batches/buy.java
+++ b/official/docs/java/current/batches/buy.java
@@ -4,11 +4,44 @@ import com.easypost.exception.EasyPostException;
 import com.easypost.model.Batch;
 import com.easypost.service.EasyPostClient;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 public class Buy {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient("EASYPOST_API_KEY");
 
-        Batch batch = client.batch.buy("batch_...");
+        List<HashMap<String, Object>> shipmentsList = new ArrayList<HashMap<String, Object>>();
+        HashMap<String, Object> shipmentMap = new HashMap<String, Object>();
+
+        HashMap<String, Object> fromAddress = new HashMap<String, Object>();
+        fromAddress.put("id", "adr_...");
+        shipmentMap.put("from_address", fromAddress);
+
+        HashMap<String, Object> toAddress = new HashMap<String, Object>();
+        toAddress.put("id", "adr_...");
+        shipmentMap.put("to_address", toAddress);
+
+        HashMap<String, Object> parcel = new HashMap<String, Object>();
+        parcel.put("id", "prcl_...");
+        shipmentMap.put("parcel", parcel);
+
+        shipmentMap.put("service", "First");
+        shipmentMap.put("carrier", "USPS");
+
+        String[] carrierAccounts = { "ca_..." };
+        shipmentMap.put("carrier_accounts", carrierAccounts);
+
+        shipmentsList.add(shipmentMap);
+
+        HashMap<String, Object> params = new HashMap<String, Object>();
+
+        params.put("shipment", shipmentsList);
+
+        Batch createdBatch = client.batch.create(params);
+
+        Batch batch = client.batch.buy(createdBatch.getId());
 
         System.out.println(batch);
     }

--- a/official/docs/java/current/brand/update.java
+++ b/official/docs/java/current/brand/update.java
@@ -11,12 +11,10 @@ public class Update {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient("EASYPOST_API_KEY");
 
-        User user = User.retrieveMe();
-
         HashMap<String, Object> params = new HashMap<>();
         params.put("color", "303F9F");
 
-        Brand brand = client.user.updateBrand(user.getId(), params);
+        Brand brand = client.user.updateBrand("user_...", params);
 
         System.out.println(brand);
     }

--- a/official/docs/java/current/brand/update.java
+++ b/official/docs/java/current/brand/update.java
@@ -2,7 +2,6 @@ package brand;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Brand;
-import com.easypost.model.User;
 import com.easypost.service.EasyPostClient;
 
 import java.util.HashMap;

--- a/official/docs/java/current/child-users/list.java
+++ b/official/docs/java/current/child-users/list.java
@@ -1,4 +1,4 @@
-package users;
+package child_users;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.ChildUserCollection;
@@ -6,7 +6,7 @@ import com.easypost.service.EasyPostClient;
 
 import java.util.HashMap;
 
-public class AllChildren {
+public class List {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient("EASYPOST_API_KEY");
 
@@ -14,7 +14,7 @@ public class AllChildren {
 
         params.put("page_size", 5);
 
-        ChildUserCollection childUsers = client.users.allChildren(params);
+        ChildUserCollection childUsers = client.user.allChildren(params);
 
         System.out.println(childUsers);
     }

--- a/official/docs/java/current/forms/create.java
+++ b/official/docs/java/current/forms/create.java
@@ -11,9 +11,6 @@ public class Create {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient("EASYPOST_API_KEY");
 
-        Shipment shipment = client.shipment.retrieve("shp_...");
-        Shipment boughtShipment = client.shipment.buy(shipment.getId(), shipment.lowestRate());
-
         HashMap<String, Object> titleMap = new HashMap<String, Object>();
         titleMap.put("title", "Square Reader");
 
@@ -29,7 +26,7 @@ public class Create {
         params.put("units", 8);
         params.put("line_items", lineItemsMap);
 
-        Shipment shipmentWithForm = client.shipment.generateForm(boughtShipment.getId(), "return_packing_slip",
+        Shipment shipment = client.shipment.generateForm("shp_...", "return_packing_slip",
                 params);
 
         System.out.println(shipment);

--- a/official/docs/java/current/referral-customers/update.java
+++ b/official/docs/java/current/referral-customers/update.java
@@ -7,6 +7,6 @@ public class Update {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient("EASYPOST_API_KEY");
 
-        client.referralCustomer.updateEmail("new_email@example.com", "user_...");
+        client.referralCustomer.updateEmail("user_...", "new_email@example.com");
     }
 }

--- a/official/docs/java/current/shipments/buy.java
+++ b/official/docs/java/current/shipments/buy.java
@@ -10,14 +10,14 @@ public class Buy {
     public static void main(String[] args) throws EasyPostException {
         EasyPostClient client = new EasyPostClient("EASYPOST_API_KEY");
 
-        Shipment shipment = client.shipment.retrieve("shp_...");
+        Shipment retrievedShipment = client.shipment.retrieve("shp_...");
 
         HashMap<String, Object> params = new HashMap<String, Object>();
-        params.put("rate", shipment.lowestRate());
+        params.put("rate", retrievedShipment.lowestRate());
         params.put("insurance", "249.99");
 
-        Shipment boughtShipment = client.shipment.buy(shipment.getId(), params);
+        Shipment shipment = client.shipment.buy(retrievedShipment.getId(), params);
 
-        System.out.println(boughtShipment);
+        System.out.println(shipment);
     }
 }

--- a/official/docs/node/current/addresses/retrieve.js
+++ b/official/docs/node/current/addresses/retrieve.js
@@ -3,7 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const retrievedAddress = await client.Address.retrieve('adr_...');
+  const address = await client.Address.retrieve('adr_...');
 
-  console.log(retrievedAddress);
+  console.log(address);
 })();

--- a/official/docs/node/current/addresses/verify.js
+++ b/official/docs/node/current/addresses/verify.js
@@ -3,17 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const address = await client.Address.create({
-    street1: '417 montgomery streat',
-    city: 'SAN FRANCISCO',
-    state: 'CA',
-    zip: '94104',
-    country: 'US',
-    company: 'EasyPost',
-    phone: '415-123-4567',
-  });
+  const address = await client.Address.verifyAddress('adr_...');
 
-  const verifiedAddress = await client.Address.verifyAddress(address.id);
-
-  console.log(verifiedAddress);
+  console.log(address);
 })();

--- a/official/docs/node/current/batches/add-shipments.js
+++ b/official/docs/node/current/batches/add-shipments.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const batch = await client.Batch.retrieve('batch_...');
+  const batch = await client.Batch.addShipments('batch_...', ['shp_...', 'shp_...']);
 
-  const batchWithShipments = await client.Batch.addShipments(batch.id, ['shp_...', 'shp_...']);
-
-  console.log(batchWithShipments);
+  console.log(batch);
 })();

--- a/official/docs/node/current/batches/buy.js
+++ b/official/docs/node/current/batches/buy.js
@@ -3,7 +3,20 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const batch = await client.Batch.buy('batch_...');
+  const createdBatch = await client.Batch.create({
+    shipments: [
+      {
+        from_address: { id: 'adr_...' },
+        to_address: { id: 'adr_...' },
+        parcel: { id: 'prcl_...' },
+        service: 'First',
+        carrier: 'USPS',
+        carrier_accounts: ['ca_...'],
+      },
+    ],
+  });
+
+  const batch = await client.Batch.buy(createdBatch.id);
 
   console.log(batch);
 })();

--- a/official/docs/node/current/batches/buy.js
+++ b/official/docs/node/current/batches/buy.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const batch = await client.Batch.retrieve('batch_...');
+  const batch = await client.Batch.buy('batch_...');
 
-  const boughtBatch = await client.Batch.buy(batch.id);
-
-  console.log(boughtBatch);
+  console.log(batch);
 })();

--- a/official/docs/node/current/batches/label.js
+++ b/official/docs/node/current/batches/label.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const batch = await client.Batch.retrieve('batch_...');
+  const batch = await client.Batch.generateLabel('batch_...', 'PDF');
 
-  const batchWithLabel = await client.Batch.generateLabel(batch.id, 'PDF');
-
-  console.log(batchWithLabel);
+  console.log(batch);
 })();

--- a/official/docs/node/current/batches/remove-shipments.js
+++ b/official/docs/node/current/batches/remove-shipments.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const batch = await client.Batch.retrieve('batch_...');
+  const batch = await client.Batch.removeShipments('batch_...', ['shp_...']);
 
-  const batchWithoutShipments = await client.Batch.removeShipments(batch.id, ['shp_...']);
-
-  console.log(batchWithoutShipments);
+  console.log(batch);
 })();

--- a/official/docs/node/current/batches/scan-forms.js
+++ b/official/docs/node/current/batches/scan-forms.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const batch = await client.Batch.retrieve('batch_...');
+  const batch = await client.Batch.createScanForm('batch_...');
 
-  const batchWithScanForm = await client.Batch.createScanForm(batch.id);
-
-  console.log(batchWithScanForm);
+  console.log(batch);
 })();

--- a/official/docs/node/current/brand/update.js
+++ b/official/docs/node/current/brand/update.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const user = await client.User.retrieveMe();
-
-  const brand = await client.User.updateBrand(user.id, { color: '#303F9F' });
+  const brand = await client.User.updateBrand('user_...', { color: '#303F9F' });
 
   console.log(brand);
 })();

--- a/official/docs/node/current/carrier-accounts/delete.js
+++ b/official/docs/node/current/carrier-accounts/delete.js
@@ -3,7 +3,5 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const carrierAccount = await client.CarrierAccount.retrieve('ca_...');
-
-  await client.CarrierAccount.delete(carrierAccount.id);
+  await client.CarrierAccount.delete('ca_...');
 })();

--- a/official/docs/node/current/carrier-accounts/update.js
+++ b/official/docs/node/current/carrier-accounts/update.js
@@ -3,12 +3,10 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const carrierAccount = await client.CarrierAccount.retrieve('ca_...');
-
-  const updatedCarrierAccount = await client.CarrierAccount.update(carrierAccount.id, {
+  const CarrierAccount = await client.CarrierAccount.update('ca_...', {
     description: 'FL Location DHL eCommerce Solutions Account',
     credentials: { pickup_id: 'abc123' },
   });
 
-  console.log(updatedCarrierAccount);
+  console.log(CarrierAccount);
 })();

--- a/official/docs/node/current/endshipper/buy.js
+++ b/official/docs/node/current/endshipper/buy.js
@@ -3,15 +3,15 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
+  const retrievedShipment = await client.Shipment.retrieve('shp_...');
 
-  const shipmentWithEndShipperId = await client.Shipment.buy(
-    shipment.id,
-    shipment.lowestRate(),
+  const shipment = await client.Shipment.buy(
+    retrievedShipment.id,
+    retrievedShipment.lowestRate(),
     null,
     false,
     'es_...',
   );
 
-  console.log(shipmentWithEndShipperId);
+  console.log(shipment);
 })();

--- a/official/docs/node/current/endshipper/update.js
+++ b/official/docs/node/current/endshipper/update.js
@@ -2,9 +2,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const endShipper = await client.EndShipper.retrieve('es_...');
-
-  const updatedEndShipper = await client.EndShipper.update(endShipper.id, {
+  const updatedEndShipper = await client.EndShipper.update('es_...', {
     name: 'NEW NAME',
     company: 'BAZ',
     street1: '164 TOWNSEND STREET UNIT 1',

--- a/official/docs/node/current/forms/create.js
+++ b/official/docs/node/current/forms/create.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
-
-  const shipmentWithForm = shipment.generateForm(shipment.id, 'return_packing_slip', {
+  const shipmentWithForm = await client.Shipment.generateForm('shp_...', 'return_packing_slip', {
     barcode: 'RMA12345678900',
     line_items: [
       {

--- a/official/docs/node/current/orders/buy.js
+++ b/official/docs/node/current/orders/buy.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const order = await client.Order.retrieve('order_...');
-
-  const boughtOrder = await client.Order.buy(order.id, 'FedEx', 'FEDEX_GROUND');
+  const boughtOrder = await client.Order.buy('order_...', 'FedEx', 'FEDEX_GROUND');
 
   console.log(boughtOrder);
 })();

--- a/official/docs/node/current/pickups/buy.js
+++ b/official/docs/node/current/pickups/buy.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const pickup = await client.Pickup.retrieve('pickup_...');
+  const pickup = await client.Pickup.buy('pickup_...', 'UPS', 'Same-day Pickup');
 
-  const boughtPickup = await client.Pickup.buy(pickup.id, 'UPS', 'Same-day Pickup');
-
-  console.log(boughtPickup);
+  console.log(pickup);
 })();

--- a/official/docs/node/current/pickups/cancel.js
+++ b/official/docs/node/current/pickups/cancel.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const pickup = await client.Pickup.retrieve('pickup_...');
-
-  const cancelledPickup = pickup.cancel(pickup.id);
+  const cancelledPickup = await client.Pickup.cancel('pickup_...');
 
   console.log(cancelledPickup);
 })();

--- a/official/docs/node/current/rates/regenerate.js
+++ b/official/docs/node/current/rates/regenerate.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
-
-  const rates = await client.Shipment.regenerateRates(shipment.id);
+  const rates = await client.Shipment.regenerateRates('shp_...');
 
   console.log(rates);
 })();

--- a/official/docs/node/current/shipments/buy.js
+++ b/official/docs/node/current/shipments/buy.js
@@ -3,9 +3,13 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
+  const retrievedShipment = await client.Shipment.retrieve('shp_...');
 
-  const boughtShipment = await client.Shipment.buy(shipment.id, shipment.lowestRate(), 249.99);
+  const shipment = await client.Shipment.buy(
+    retrievedShipment.id,
+    retrievedShipment.lowestRate(),
+    249.99,
+  );
 
-  console.log(boughtShipment);
+  console.log(shipment);
 })();

--- a/official/docs/node/current/shipments/label.js
+++ b/official/docs/node/current/shipments/label.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
+  const shipment = await client.Shipment.convertLabelFormat('shp_...', 'ZPL');
 
-  const shipmentWithLabel = await client.Shipment.convertLabelFormat(shipment.id, 'ZPL');
-
-  console.log(shipmentWithLabel);
+  console.log(shipment);
 })();

--- a/official/docs/node/current/shipping-insurance/insure.js
+++ b/official/docs/node/current/shipping-insurance/insure.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
+  const shipment = await client.Shipment.insure('shp_...', 100);
 
-  const insuredShipment = await client.Shipment.insure(shipment.id, 100);
-
-  console.log(insuredShipment);
+  console.log(shipment);
 })();

--- a/official/docs/node/current/shipping-refund/refund.js
+++ b/official/docs/node/current/shipping-refund/refund.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
+  const shipment = await client.Shipment.refund('shp_...');
 
-  const refundedShipment = await client.Shipment.refund(shipment.id);
-
-  console.log(refundedShipment);
+  console.log(shipment);
 })();

--- a/official/docs/node/current/smartrate/retrieve-estimated-delivery-date.js
+++ b/official/docs/node/current/smartrate/retrieve-estimated-delivery-date.js
@@ -3,10 +3,8 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
-
   const estimatedDeliveryDates = await client.Shipment.retrieveEstimatedDeliveryDate(
-    shipment.id,
+    'shp_...',
     'YYYY-MM-DD',
   );
 

--- a/official/docs/node/current/smartrate/retrieve-time-in-transit-statistics.js
+++ b/official/docs/node/current/smartrate/retrieve-time-in-transit-statistics.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const shipment = await client.Shipment.retrieve('shp_...');
-
-  const smartRates = shipment.getSmartrates(shipment.id);
+  const smartRates = await client.Shipment.getSmartrates('shp_...');
 
   console.log(smartRates);
 })();

--- a/official/docs/node/current/users/update.js
+++ b/official/docs/node/current/users/update.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const user = await client.User.retrieveMe();
+  const user = await client.User.update('user_...', { recharge_threshold: '50.00' });
 
-  const updatedUser = await client.User.update(user.id, { recharge_threshold: '50.00' });
-
-  console.log(updatedUser);
+  console.log(user);
 })();

--- a/official/docs/node/current/webhooks/update.js
+++ b/official/docs/node/current/webhooks/update.js
@@ -3,9 +3,7 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const webhook = await client.Webhook.retrieve('hook_...');
+  const webhook = await client.Webhook.update('hook_...');
 
-  const updatedWebhook = await client.Webhook.update(webhook.id);
-
-  console.log(updatedWebhook);
+  console.log(webhook);
 })();

--- a/official/docs/php/current/addresses/verify.php
+++ b/official/docs/php/current/addresses/verify.php
@@ -2,17 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$address = $client->address->create([
-    'street1' => '417 montgomery streat',
-    'street2' => 'FL 5',
-    'city'    => 'San Francisco',
-    'state'   => 'CA',
-    'zip'     => '94104',
-    'country' => 'US',
-    'company' => 'EasyPost',
-    'phone'   => '415-123-4567'
-]);
+$address = $client->address->verify('adr_...');
 
-$verifiedAddress = $client->address->verify($address->id);
-
-echo $verifiedAddress;
+echo $address;

--- a/official/docs/php/current/batches/add-shipments.php
+++ b/official/docs/php/current/batches/add-shipments.php
@@ -2,10 +2,8 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$batch = $client->batch->retrieve('batch_...');
-
-$batchWithShipments = $client->batch->addShipments(
-    $batch->id,
+$batch = $client->batch->addShipments(
+    'batch_...',
     [
         'shipments' => [
             ['id' => 'shp_...'],
@@ -14,4 +12,4 @@ $batchWithShipments = $client->batch->addShipments(
     ]
 );
 
-echo $batchWithShipments;
+echo $batch;

--- a/official/docs/php/current/batches/buy.php
+++ b/official/docs/php/current/batches/buy.php
@@ -2,6 +2,17 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$batch = $client->batch->buy('batch_...');
+$createdBatch = $client->batch->create([
+    'shipments' => [
+        ['from_address' => ['id' => 'adr_...']],
+        ['to_address' => ['id' => 'adr_...']],
+        ['parcel' => ['id' => 'prcl_...']],
+        ['service' => 'First'],
+        ['carrier' => 'USPS'],
+        ['carrier_accounts' => ['ca_...']],
+    ]
+]);
+
+$batch = $client->batch->buy($createdBatch['id']);
 
 echo $batch;

--- a/official/docs/php/current/batches/buy.php
+++ b/official/docs/php/current/batches/buy.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$batch = $client->batch->retrieve('batch_...');
+$batch = $client->batch->buy('batch_...');
 
-$boughtBatch = $client->batch->buy($batch->id);
-
-echo $boughtBatch;
+echo $batch;

--- a/official/docs/php/current/batches/label.php
+++ b/official/docs/php/current/batches/label.php
@@ -2,10 +2,8 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$batch = $client->batch->retrieve('batch_...');
-
 $batchWithLabel = $client->batch->label(
-    $batch->id,
+    'batch_...',
     ['file_format' => 'PDF']
 );
 

--- a/official/docs/php/current/batches/remove-shipments.php
+++ b/official/docs/php/current/batches/remove-shipments.php
@@ -2,10 +2,8 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$batch = $client->batch->retrieve('batch_...');
-
-$batchWithoutShipments = $client->batch->removeShipments(
-    $shipment->id,
+$batch = $client->batch->removeShipments(
+    'batch_...',
     [
         'shipments' => [
             ['id' => 'shp_...']
@@ -13,4 +11,4 @@ $batchWithoutShipments = $client->batch->removeShipments(
     ]
 );
 
-echo $batchWithoutShipments;
+echo $batch;

--- a/official/docs/php/current/batches/scan-forms.php
+++ b/official/docs/php/current/batches/scan-forms.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$batch = $client->batch->retrieve('batch_...');
+$batch = $client->batch->createScanForm('batch_...');
 
-$batchWithScanForm = $client->batch->createScanForm($batch->id);
-
-echo $batchWithScanForm;
+echo $batch;

--- a/official/docs/php/current/brand/update.php
+++ b/official/docs/php/current/brand/update.php
@@ -2,10 +2,8 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$user = $client->user->retrieveMe();
-
 $brand = $client->user->updateBrand(
-    $user->id,
+    'user_...',
     ['color' => '#303F9F']
 );
 

--- a/official/docs/php/current/carrier-accounts/delete.php
+++ b/official/docs/php/current/carrier-accounts/delete.php
@@ -2,6 +2,4 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$carrierAccount = $client->carrierAccount->retrieve('ca_...');
-
-$client->carrierAccount->delete($carrierAccount->id);
+$client->carrierAccount->delete('ca_...');

--- a/official/docs/php/current/carrier-accounts/update.php
+++ b/official/docs/php/current/carrier-accounts/update.php
@@ -2,10 +2,8 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$carrierAccount = $client->carrierAccount->retrieve('ca_...');
-
-$updatedCarrierAccount = $client->carrierAccount->update(
-    $carrierAccount->id,
+$carrierAccount = $client->carrierAccount->update(
+    'ca_...',
     [
         'description' => 'FL Location DHL eCommerce Solutions Account',
         'credentials' => [
@@ -14,4 +12,4 @@ $updatedCarrierAccount = $client->carrierAccount->update(
     ]
 );
 
-echo $updatedCarrierAccount;
+echo $carrierAccount;

--- a/official/docs/php/current/child-users/delete.php
+++ b/official/docs/php/current/child-users/delete.php
@@ -2,6 +2,4 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$user = $client->user->retrieve('user_...');
-
-$client->user->delete($user->id);
+$client->user->delete('user_...');

--- a/official/docs/php/current/endshipper/buy.php
+++ b/official/docs/php/current/endshipper/buy.php
@@ -2,16 +2,16 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
+$retrievedShipment = $client->shipment->retrieve('shp_...');
 
-$boughtShipment = $client->shipment->buy(
-    $shipment->id,
+$shipment = $client->shipment->buy(
+    $retrievedShipment->id,
     [
-        'rate'      => $shipment->lowestRate(),
+        'rate'      => $retrievedShipment->lowestRate(),
         'insurance' => null,
         'with_carbon_offset' => false,
         'end_shipper_id' => 'es_...'
     ]
 );
 
-echo $boughtShipment;
+echo $shipment;

--- a/official/docs/php/current/endshipper/update.php
+++ b/official/docs/php/current/endshipper/update.php
@@ -2,10 +2,8 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$endshipper = $client->endShipper->retrieve('es_...');
-
-$updatedEndShipper = $client->endShipper->update(
-    $endShipper->id,
+$endShipper = $client->endShipper->update(
+    'es_...',
     [
         'name' => 'NEW NAME',
         'company' => 'BAZ',
@@ -20,4 +18,4 @@ $updatedEndShipper = $client->endShipper->update(
     ]
 );
 
-echo $updatedEndShipper;
+echo $endShipper;

--- a/official/docs/php/current/forms/create.php
+++ b/official/docs/php/current/forms/create.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
-
 $formType = 'return_packing_slip';
 $formOptions = [
     'barcode' => 'RMA12345678900',
@@ -18,6 +16,6 @@ $formOptions = [
     ],
 ];
 
-$shipmentWithForm = $client->shipment->generateForm($shipment->id, $formType, $formOptions);
+$shipmentWithForm = $client->shipment->generateForm('shp_...', $formType, $formOptions);
 
 echo $shipmentWithForm;

--- a/official/docs/php/current/orders/buy.php
+++ b/official/docs/php/current/orders/buy.php
@@ -2,14 +2,12 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$order = $client->order->retrieve('order_...');
-
-$boughtOrder = $client->order->buy(
-    $shipment->id,
+$order = $client->order->buy(
+    'order_...',
     [
         'carrier' => 'FedEx',
         'service' => 'FEDEX_GROUND'
     ]
 );
 
-echo $boughtOrder;
+echo $order;

--- a/official/docs/php/current/pickups/buy.php
+++ b/official/docs/php/current/pickups/buy.php
@@ -2,10 +2,8 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$pickup = $client->pickup->retrieve('pickup_...');
-
-$boughtPickup = $client->pickup->buy(
-    $pickup->id,
+$pickup = $client->pickup->buy(
+    'pickup_...',
     [
         'carrier' => 'UPS',
         'service' => 'Same-day Pickup'

--- a/official/docs/php/current/pickups/cancel.php
+++ b/official/docs/php/current/pickups/cancel.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$pickup = $client->pickup->retrieve('pickup_...');
+$pickup = $client->pickup->cancel('pickup_...');
 
-$cancelledPickup = $client->pickup->cancel($pickup->id);
-
-echo $cancelledPickup;
+echo $pickup;

--- a/official/docs/php/current/rates/regenerate.php
+++ b/official/docs/php/current/rates/regenerate.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
+$shipment = $client->shipment->regenerateRates('shp_...');
 
-$shipmentWithRegeneratedrates = $client->shipment->regenerateRates($shipment->id);
-
-echo $shipmentWithRegeneratedrates;
+echo $shipment;

--- a/official/docs/php/current/shipments/buy.php
+++ b/official/docs/php/current/shipments/buy.php
@@ -2,14 +2,12 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
-
-$boughtShipment = $client->shipment->buy(
-    $shipment->id,
+$shipment = $client->shipment->buy(
+    'shp_...',
     [
         'rate'      => $shipment->lowestRate(),
         'insurance' => 249.99
     ]
 );
 
-echo $boughtShipment;
+echo $shipment;

--- a/official/docs/php/current/shipments/label.php
+++ b/official/docs/php/current/shipments/label.php
@@ -2,10 +2,8 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
-
-$shipmentWithLabel = $client->shipment->label(
-    $shipment->id,
+$shipment = $client->shipment->label(
+    'shp_...',
     ['file_format' => 'ZPL']
 );
 

--- a/official/docs/php/current/shipping-insurance/insure.php
+++ b/official/docs/php/current/shipping-insurance/insure.php
@@ -2,11 +2,9 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
-
-$shipmentWithInsurance = $client->shipment->insure(
-    $shipment->id,
+$shipment = $client->shipment->insure(
+    'shp_...',
     ['amount' => 100]
 );
 
-echo $shipmentWithInsurance;
+echo $shipment;

--- a/official/docs/php/current/shipping-refund/refund.php
+++ b/official/docs/php/current/shipping-refund/refund.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
+$shipment = $client->shipment->refund('shp_...');
 
-$refundedShipment = $client->shipment->refund($shipment->id);
-
-echo $refundedShipment;
+echo $shipment;

--- a/official/docs/php/current/smartrate/retrieve-estimated-delivery-date.php
+++ b/official/docs/php/current/smartrate/retrieve-estimated-delivery-date.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
-
-$estimatedDeliveryDates = $client->shipment->retrieveEstimatedDeliveryDate($shipment->id, 'YYYY-MM-DD');
+$estimatedDeliveryDates = $client->shipment->retrieveEstimatedDeliveryDate('shp_...', 'YYYY-MM-DD');
 
 echo $estimatedDeliveryDates;

--- a/official/docs/php/current/smartrate/retrieve-time-in-transit-statistics.php
+++ b/official/docs/php/current/smartrate/retrieve-time-in-transit-statistics.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$shipment = $client->shipment->retrieve('shp_...');
-
-$smartRates = $client->shipment->getSmartrates();
+$smartRates = $client->shipment->getSmartrates('shp_...');
 
 echo $smartRates;

--- a/official/docs/php/current/users/update.php
+++ b/official/docs/php/current/users/update.php
@@ -2,11 +2,9 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$user = $client->user->retrieveMe();
-
-$updatedUser = $client->user->update(
-    $user->id,
+$user = $client->user->update(
+    'user_...',
     ['recharge_threshold' => '50.00']
 );
 
-echo $updatedUser;
+echo $user;

--- a/official/docs/php/current/webhooks/delete.php
+++ b/official/docs/php/current/webhooks/delete.php
@@ -2,6 +2,4 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$webhook = $client->webhook->retrieve('hook_...');
-
-$client->webhook->delete($webhook->id);
+$client->webhook->delete('hook_...');

--- a/official/docs/php/current/webhooks/update.php
+++ b/official/docs/php/current/webhooks/update.php
@@ -2,8 +2,6 @@
 
 $client = new \EasyPost\EasyPostClient('EASYPOST_API_KEY');
 
-$webhook = $client->webhook->retrieve('hook_...');
+$webhook = $client->webhook->update('hook_...');
 
-$updatedWebhook = $client->webhook->update();
-
-echo $updatedWebhook;
+echo $webhook;

--- a/official/docs/python/current/addresses/verify.py
+++ b/official/docs/python/current/addresses/verify.py
@@ -2,17 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-address = client.address.create(
-    street1="417 MONTGOMERY ST",
-    street2="FLOOR 5",
-    city="San Francisco",
-    state="CA",
-    zip="94104",
-    country="US",
-    company="EasyPost",
-    phone="415-123-4567",
-)
+address = client.address.verify("adr_...")
 
-verified_address = client.address.verify(address.id)
-
-print(verified_address)
+print(address)

--- a/official/docs/python/current/batches/add-shipments.py
+++ b/official/docs/python/current/batches/add-shipments.py
@@ -2,14 +2,12 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-batch = client.batch.retrieve("batch_...")
-
-batch_with_shipments = client.batch.add_shipments(
-    batch.id,
+batch = client.batch.add_shipments(
+    "batch_...",
     shipments=[
         {"id": "shp_..."},
         {"id": "shp_..."},
     ],
 )
 
-print(batch_with_shipments)
+print(batch)

--- a/official/docs/python/current/batches/buy.py
+++ b/official/docs/python/current/batches/buy.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-batch = client.batch.retrieve("batch_...")
+batch = client.batch.buy("batch_...")
 
-bought_batch = client.batch.buy(batch.id)
-
-print(bought_batch)
+print(batch)

--- a/official/docs/python/current/batches/buy.py
+++ b/official/docs/python/current/batches/buy.py
@@ -2,6 +2,19 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-batch = client.batch.buy("batch_...")
+createdBatch = client.batch.create(
+    shipments=[
+        {
+            "from_address": {"id": "adr_..."},
+            "to_address": {"id": "adr_..."},
+            "parcel": {"id": "prcl_..."},
+            "service": "First",
+            "carrier": "USPS",
+            "carrier_accounts": ["ca_..."],
+        },
+    ],
+)
+
+batch = client.batch.buy(createdBatch["id"])
 
 print(batch)

--- a/official/docs/python/current/batches/label.py
+++ b/official/docs/python/current/batches/label.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-batch = client.batch.retrieve("batch_...")
+batch = client.batch.label("batch_...", file_format="PDF")
 
-batch_with_label = client.batch.label(batch.id, file_format="PDF")
-
-print(batch_with_label)
+print(batch)

--- a/official/docs/python/current/batches/remove-shipments.py
+++ b/official/docs/python/current/batches/remove-shipments.py
@@ -2,10 +2,8 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-batch = client.batch.retrieve("batch_...")
-
-batch_without_shipments = batch.remove_shipments(
-    batch.id,
+batch = batch.remove_shipments(
+    "batch_...",
     shipments=[
         {
             "id": "shp_...",
@@ -13,4 +11,4 @@ batch_without_shipments = batch.remove_shipments(
     ],
 )
 
-print(batch_without_shipments)
+print(batch)

--- a/official/docs/python/current/batches/scan-forms.py
+++ b/official/docs/python/current/batches/scan-forms.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-batch = client.batch.retrieve("batch_...")
+batch = client.batch.create_scan_form("batch_...")
 
-batch_with_scan_form = client.batch.create_scan_form(batch.id)
-
-print(batch_with_scan_form)
+print(batch)

--- a/official/docs/python/current/brand/update.py
+++ b/official/docs/python/current/brand/update.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-user = client.user.retrieve_me()
+brand = client.user.update_brand("user_...", color="#303F9F")
 
-updated_brand = client.user.update_brand(user.id, color="#303F9F")
-
-print(updated_brand)
+print(brand)

--- a/official/docs/python/current/carrier-accounts/delete.py
+++ b/official/docs/python/current/carrier-accounts/delete.py
@@ -2,6 +2,4 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-carrier_account = client.carrier_account.retrieve("ca_...")
-
-client.carrier_account.delete(carrier_account.id)
+client.carrier_account.delete("ca_...")

--- a/official/docs/python/current/carrier-accounts/update.py
+++ b/official/docs/python/current/carrier-accounts/update.py
@@ -2,10 +2,8 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-carrier_account = client.carrier_account.retrieve("ca_...")
-
 updated_carrier_account = client.carrier_account.update(
-    carrier_account.id,
+    "ca_...",
     description="FL Location DHL eCommerce Solutions Account",
     credentials={"pickup_id": "abc123"},
 )

--- a/official/docs/python/current/carrier-metadata/retrieve.py
+++ b/official/docs/python/current/carrier-metadata/retrieve.py
@@ -4,11 +4,11 @@ client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
 # Request all metadata for all carriers
 carrier_metadata = client.carrier_metadata.retrieve()
+print(carrier_metadata)
 
 # Request specific metadata for specific carriers
 carrier_metadata = client.carrier_metadata.retrieve(
     carriers=["usps"],
     types=["service_levels", "predefined_packages"],
 )
-
 print(carrier_metadata)

--- a/official/docs/python/current/child-users/delete.py
+++ b/official/docs/python/current/child-users/delete.py
@@ -2,6 +2,4 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-user = client.user.retrieve("user_...")
-
-client.user.delete(user.id)
+client.user.delete("user_...")

--- a/official/docs/python/current/endshipper/retrieve.py
+++ b/official/docs/python/current/endshipper/retrieve.py
@@ -2,6 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-retrieved_endshipper = client.end_shipper.retrieve("es_...")
+end_shipper = client.end_shipper.retrieve("es_...")
 
-print(retrieved_endshipper)
+print(end_shipper)

--- a/official/docs/python/current/endshipper/update.py
+++ b/official/docs/python/current/endshipper/update.py
@@ -2,10 +2,8 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-end_shipper = client.end_shipper.retrieve("es_...")
-
-updated_end_shipper = client.end_shipper.update(
-    end_shipper.id,
+end_shipper = client.end_shipper.update(
+    "es_...",
     name="NEW NAME",
     company="BAZ",
     street1="164 TOWNSEND STREET UNIT 1",
@@ -18,4 +16,4 @@ updated_end_shipper = client.end_shipper.update(
     email="FOO@EXAMPLE.COM",
 )
 
-print(updated_end_shipper)
+print(end_shipper)

--- a/official/docs/python/current/forms/create.py
+++ b/official/docs/python/current/forms/create.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipment = client.shipment.retrieve("shp_...")
-
 form_type = "return_packing_slip"
 form_options = {
     "barcode": "RMA12345678900",
@@ -18,6 +16,6 @@ form_options = {
     ],
 }
 
-shipment_with_form = client.shipment.generate_form(shipment.id, form_type, form_options)
+shipment = client.shipment.generate_form("shp_...", form_type, form_options)
 
-print(shipment_with_form)
+print(shipment)

--- a/official/docs/python/current/orders/buy.py
+++ b/official/docs/python/current/orders/buy.py
@@ -2,9 +2,8 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-order = client.order.retrieve("order_...")
 bought_order = client.order.buy(
-    order.id,
+    "order_...",
     carrier="FedEx",
     service="FEDEX_GROUND",
 )

--- a/official/docs/python/current/pickups/buy.py
+++ b/official/docs/python/current/pickups/buy.py
@@ -2,13 +2,10 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-
-pickup = client.pickup.retrieve("pickup_...")
-
-bought_pickup = client.pickup.buy(
-    pickup.id,
+pickup = client.pickup.buy(
+    "pickup_...",
     carrier="UPS",
     service="Same-day Pickup",
 )
 
-print(bought_pickup)
+print(pickup)

--- a/official/docs/python/current/pickups/cancel.py
+++ b/official/docs/python/current/pickups/cancel.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-pickup = client.pickup.retrieve("pickup_...")
+pickup = client.pickup.cancel("pickup_...")
 
-cancelled_pickup = client.pickup.cancel(pickup.id)
-
-print(cancelled_pickup)
+print(pickup)

--- a/official/docs/python/current/rates/regenerate.py
+++ b/official/docs/python/current/rates/regenerate.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipment = client.shipment.retrieve("shp_...")
+shipment = client.shipment.regenerate_rates("shp_...")
 
-shipment_with_regenerated_rates = client.shipment.regenerate_rates(shipment.id)
-
-print(shipment_with_regenerated_rates)
+print(shipment)

--- a/official/docs/python/current/referral-customers/update.py
+++ b/official/docs/python/current/referral-customers/update.py
@@ -2,10 +2,7 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-user = client.user.retrieve("usr_...")
-
 client.referral_customer.update_email(
-    user.id,
+    "usr_...",
     "new_email@example.com",
-    "user_...",
 )

--- a/official/docs/python/current/shipments/buy.py
+++ b/official/docs/python/current/shipments/buy.py
@@ -2,12 +2,12 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipment = client.shipment.retrieve("shp_...")
+retrieved_shipment = client.shipment.retrieve("shp_...")
 
-bought_shipment = client.shipment.buy(
-    shipment.id,
-    rate=shipment.lowest_rate(),
+shipment = client.shipment.buy(
+    retrieved_shipment.id,
+    rate=retrieved_shipment.lowest_rate(),
     insurance=249.99,
 )
 
-print(bought_shipment)
+print(shipment)

--- a/official/docs/python/current/shipments/label.py
+++ b/official/docs/python/current/shipments/label.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipment = client.shipment.retrieve("shp_...")
+shipment = client.shipment.label("shp_...", file_format="ZPL")
 
-shipment_with_label = client.shipment.label(shipment.id, file_format="ZPL")
-
-print(shipment_with_label)
+print(shipment)

--- a/official/docs/python/current/shipments/list.py
+++ b/official/docs/python/current/shipments/list.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipments = client.shipment.all(
-    page_size=5,
-)
+shipments = client.shipment.all(page_size=5)
 
 print(shipments)

--- a/official/docs/python/current/shipments/list.py
+++ b/official/docs/python/current/shipments/list.py
@@ -2,6 +2,8 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipments = client.shipment.all(page_size=5)
+shipments = client.shipment.all(
+    page_size=5,
+)
 
 print(shipments)

--- a/official/docs/python/current/shipping-insurance/insure.py
+++ b/official/docs/python/current/shipping-insurance/insure.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipment = client.shipment.retrieve("shp_...")
+shipment = client.shipment.insure("shp_...", amount=100)
 
-insured_shipment = client.shipment.insure(shipment.id, amount=100)
-
-print(insured_shipment)
+print(shipment)

--- a/official/docs/python/current/shipping-refund/refund.py
+++ b/official/docs/python/current/shipping-refund/refund.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipment = client.shipment.retrieve("shp_...")
+shipment = client.shipment.refund("shp_...")
 
-refunded_shipment = client.shipment.refund(shipment.id)
-
-print(refunded_shipment)
+print(shipment)

--- a/official/docs/python/current/smartrate/retrieve-estimated-delivery-date.py
+++ b/official/docs/python/current/smartrate/retrieve-estimated-delivery-date.py
@@ -2,10 +2,8 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipment = client.shipment.retrieve("shp_...")
-
 estimated_delivery_dates = client.shipment.retrieve_estimated_delivery_date(
-    shipment.id,
+    "shp_...",
     planned_ship_date="YYYY-MM-DD",
 )
 

--- a/official/docs/python/current/smartrate/retrieve-time-in-transit-statistics.py
+++ b/official/docs/python/current/smartrate/retrieve-time-in-transit-statistics.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-shipment = client.shipment.retrieve("shp_...")
-
-smart_rates = client.shipment.get_smart_rates(shipment.id)
+smart_rates = client.shipment.get_smart_rates("shp_...")
 
 print(smart_rates)

--- a/official/docs/python/current/trackers/list.py
+++ b/official/docs/python/current/trackers/list.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-trackers = client.tracker.all(
-    page_size=5,
-)
+trackers = client.tracker.all(page_size=5)
 
 print(trackers)

--- a/official/docs/python/current/trackers/list.py
+++ b/official/docs/python/current/trackers/list.py
@@ -2,6 +2,8 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-trackers = client.tracker.all(page_size=5)
+trackers = client.tracker.all(
+    page_size=5,
+)
 
 print(trackers)

--- a/official/docs/python/current/webhooks/delete.py
+++ b/official/docs/python/current/webhooks/delete.py
@@ -2,6 +2,4 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-webhook = client.webhook.retrieve("hook_...")
-
-client.webhook.delete(webhook.id)
+client.webhook.delete("hook_...")

--- a/official/docs/python/current/webhooks/update.py
+++ b/official/docs/python/current/webhooks/update.py
@@ -2,8 +2,6 @@ import easypost
 
 client = easypost.EasyPostClient("EASYPOST_API_KEY")
 
-webhook = client.webhook.retrieve("hook_...")
-
-updated_webhook = client.webhook.update(webhook.id)
+updated_webhook = client.webhook.update("hook_...")
 
 print(updated_webhook)

--- a/official/docs/ruby/current/addresses/verify.rb
+++ b/official/docs/ruby/current/addresses/verify.rb
@@ -2,17 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-address = client.address.create(
-  street1: '417 MONTGOMERY ST',
-  street2: 'FLOOR 5',
-  city: 'SAN FRANCISCO',
-  state: 'CA',
-  zip: '94104',
-  country: 'US',
-  company: 'EasyPost',
-  phone: '415-123-4567',
-)
+address = client.address.verify('adr_...')
 
-verified_address = client.address.verify(address.id)
-
-puts verified_address
+puts address

--- a/official/docs/ruby/current/batches/add-shipments.rb
+++ b/official/docs/ruby/current/batches/add-shipments.rb
@@ -2,10 +2,8 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_batch = client.batch.retrieve('batch_...')
-
 batch = client.batch.add_shipments(
-  retrieved_batch.id,
+  'batch_...',
   shipments: [
     { id: 'shp_...' },
     { id: 'shp_...' },

--- a/official/docs/ruby/current/batches/buy.rb
+++ b/official/docs/ruby/current/batches/buy.rb
@@ -2,6 +2,19 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-batch = client.batch.buy('batch_...')
+created_batch = client.batch.create(
+  shipments: [
+    {
+      from_address: { id: 'adr_...' },
+      to_address: { id: 'adr_...' },
+      parcel: { id: 'prcl_...' },
+      service: 'First',
+      carrier: 'USPS',
+      carrier_accounts: ['ca_...'],
+    },
+  ],
+)
+
+batch = client.batch.buy(created_batch.id)
 
 puts batch

--- a/official/docs/ruby/current/batches/create.rb
+++ b/official/docs/ruby/current/batches/create.rb
@@ -3,7 +3,6 @@ require 'easypost'
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
 batch = client.batch.create(
-  'batch_...',
   shipments: [
     { id: 'shp_...' },
     { id: 'shp_...' },

--- a/official/docs/ruby/current/batches/create.rb
+++ b/official/docs/ruby/current/batches/create.rb
@@ -2,10 +2,8 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_batch = client.batch.retrieve('batch_...')
-
 batch = client.batch.create(
-  retrieved_batch.id,
+  'batch_...',
   shipments: [
     { id: 'shp_...' },
     { id: 'shp_...' },

--- a/official/docs/ruby/current/batches/label.rb
+++ b/official/docs/ruby/current/batches/label.rb
@@ -2,11 +2,9 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_batch = client.batch.retrieve('batch_...')
-
-label_batch = client.batch.label(
-  retrieved_batch.id,
+batch = client.batch.label(
+  'batch_...',
   file_format: 'PDF',
 )
 
-puts label_batch
+puts batch

--- a/official/docs/ruby/current/batches/remove-shipments.rb
+++ b/official/docs/ruby/current/batches/remove-shipments.rb
@@ -2,10 +2,8 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_batch = client.batch.retrieve('batch_...')
-
 batch = client.batch.remove_shipments(
-  retrieved_batch.id,
+  'batch_...',
   shipments: [
     { id: 'shp_...' },
   ],

--- a/official/docs/ruby/current/batches/scan-forms.rb
+++ b/official/docs/ruby/current/batches/scan-forms.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_batch = client.batch.retrieve('batch_...')
-
-batch = client.batch.create_scan_form(retrieved_batch.id)
+batch = client.batch.create_scan_form('batch_...')
 
 puts batch

--- a/official/docs/ruby/current/brand/update.rb
+++ b/official/docs/ruby/current/brand/update.rb
@@ -2,10 +2,8 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-user = client.user.retrieve_me
-
 brand = client.user.update_brand(
-  user.id,
+  'user_...',
   color: '#303F9F',
 )
 

--- a/official/docs/ruby/current/carrier-accounts/delete.rb
+++ b/official/docs/ruby/current/carrier-accounts/delete.rb
@@ -2,6 +2,4 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_carrier_account = client.carrier_account.retrieve('ca_...')
-
-client.carrier_account.delete(retrieved_carrier_account.id)
+client.carrier_account.delete('ca_...')

--- a/official/docs/ruby/current/carrier-accounts/update.rb
+++ b/official/docs/ruby/current/carrier-accounts/update.rb
@@ -2,10 +2,8 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retreived_carrier_account = client.carrier_account.retrieve('ca_...')
-
 carrier_account = client.carrier_account.update(
-  retreived_carrier_account.id,
+  'ca_...',
   description: 'FL Location DHL eCommerce Solutions Account',
 )
 

--- a/official/docs/ruby/current/child-users/delete.rb
+++ b/official/docs/ruby/current/child-users/delete.rb
@@ -2,6 +2,4 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_user = client.user.retrieve('user_...')
-
-client.user.delete(retrieved_user.id)
+client.user.delete('user_...')

--- a/official/docs/ruby/current/endshipper/buy.rb
+++ b/official/docs/ruby/current/endshipper/buy.rb
@@ -3,14 +3,13 @@ require 'easypost'
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
 retrieved_shipment = client.shipment.retrieve('shp_...')
-end_shipper = client.end_shipper.retrieve('es_...')
 
 shipment = client.shipment.buy(
   retrieved_shipment.id,
-  rate: shipment.lowest_rate,
+  rate: retrieved_shipment.lowest_rate,
   insurance: nil,
   with_carbon_offset: false,
-  end_shipper_id: end_shipper.id,
+  end_shipper_id: 'es_...',
 )
 
 puts shipment

--- a/official/docs/ruby/current/endshipper/update.rb
+++ b/official/docs/ruby/current/endshipper/update.rb
@@ -2,20 +2,19 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_endshipper = client.end_shipper.retrieve('es_...')
-
-update_data = {
-  'name' => 'New Name',
-  'street1' => '388 Townsend St',
-  'street2' => 'Apt 20',
-  'city' => 'San Francisco',
-  'state' => 'CA',
-  'zip' => '94107',
-  'country' => 'US',
-  'email' => 'test@example.com',
-  'phone' => '5555555555',
-}
-
-end_shipper = client.end_shipper.update(retrieved_endshipper.id, update_data)
+end_shipper = client.end_shipper.update(
+  'es_...',
+  {
+    'name' => 'New Name',
+    'street1' => '388 Townsend St',
+    'street2' => 'Apt 20',
+    'city' => 'San Francisco',
+    'state' => 'CA',
+    'zip' => '94107',
+    'country' => 'US',
+    'email' => 'test@example.com',
+    'phone' => '5555555555',
+  },
+)
 
 puts end_shipper

--- a/official/docs/ruby/current/forms/create.rb
+++ b/official/docs/ruby/current/forms/create.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.event.retrieve('shp_...')
-
 form_type = 'return_packing_slip'
 form_options = {
   type: 'return_packing_slip',
@@ -19,6 +17,6 @@ form_options = {
   ],
 }
 
-shipment = client.shipment.generate_form(retrieved_shipment.id, form_type, form_options)
+shipment = client.shipment.generate_form('shp_...', form_type, form_options)
 
 puts shipment

--- a/official/docs/ruby/current/orders/buy.rb
+++ b/official/docs/ruby/current/orders/buy.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_order = client.order.retrieve('order_...')
-
-order = client.order.buy(retrieved_order.id, carrier: 'FedEx', service: 'FEDEX_GROUND')
+order = client.order.buy('order_...', carrier: 'FedEx', service: 'FEDEX_GROUND')
 
 puts order

--- a/official/docs/ruby/current/pickups/buy.rb
+++ b/official/docs/ruby/current/pickups/buy.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_pickup = client.pickup.retrieve('pickup_...')
-
-pickup = client.pickup.buy(retrieved_pickup.id, carrier: 'UPS', service: 'Same-Day Pickup')
+pickup = client.pickup.buy('pickup_...', carrier: 'UPS', service: 'Same-Day Pickup')
 
 puts pickup

--- a/official/docs/ruby/current/pickups/cancel.rb
+++ b/official/docs/ruby/current/pickups/cancel.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_pickup = client.pickup.retrieve('pickup_...')
-
-pickup = client.pickup.cancel(retrieved_pickup.id)
+pickup = client.pickup.cancel('pickup_...')
 
 puts pickup

--- a/official/docs/ruby/current/rates/regenerate.rb
+++ b/official/docs/ruby/current/rates/regenerate.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.shipment.retrieve('shp_...')
-
-shipment = client.shipment.regenerate_rates(retrieved_shipment.id)
+shipment = client.shipment.regenerate_rates('shp_...')
 
 puts shipment

--- a/official/docs/ruby/current/referral-customers/update.rb
+++ b/official/docs/ruby/current/referral-customers/update.rb
@@ -3,8 +3,8 @@ require 'easypost'
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
 message = client.referral_customer.update_email(
-  'new_email@example.com',
   'user_...',
+  'new_email@example.com',
 )
 
 puts message

--- a/official/docs/ruby/current/shipments/buy.rb
+++ b/official/docs/ruby/current/shipments/buy.rb
@@ -2,11 +2,11 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.shipment.retrieve('shp_...')
+retrieved_shipment = client.shipment.retrieve()
 
 shipment = client.shipment.buy(
   retrieved_shipment.id,
-  rate: shipment.lowest_rate,
+  rate: retrieved_shipment.lowest_rate,
   insurance: '244.99',
 )
 

--- a/official/docs/ruby/current/shipments/buy.rb
+++ b/official/docs/ruby/current/shipments/buy.rb
@@ -2,7 +2,7 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.shipment.retrieve()
+retrieved_shipment = client.shipment.retrieve
 
 shipment = client.shipment.buy(
   retrieved_shipment.id,

--- a/official/docs/ruby/current/shipments/label.rb
+++ b/official/docs/ruby/current/shipments/label.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.shipment.retrieve('shp_...')
-
-shipment = client.shipment.label(retrieved_shipment.id, file_format: 'ZPL')
+shipment = client.shipment.label('shp_...', file_format: 'ZPL')
 
 puts shipment

--- a/official/docs/ruby/current/shipping-insurance/insure.rb
+++ b/official/docs/ruby/current/shipping-insurance/insure.rb
@@ -2,7 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.shipment.retrieve('shp_...')
-shipment = client.shipment.insure(retrieved_shipment.id, amount: 100)
+shipment = client.shipment.insure('shp_...', amount: 100)
 
 puts shipment

--- a/official/docs/ruby/current/shipping-refund/refund.rb
+++ b/official/docs/ruby/current/shipping-refund/refund.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.shipment.retrieve('shp_...')
-
-shipment = client.shipment.refund(retrieved_shipment.id)
+shipment = client.shipment.refund('shp_...')
 
 puts shipment

--- a/official/docs/ruby/current/smartrate/retrieve-estimated-delivery-date.rb
+++ b/official/docs/ruby/current/smartrate/retrieve-estimated-delivery-date.rb
@@ -2,10 +2,8 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.shipment.retrieve('shp_...')
-
 estimated_delivery_dates = client.shipment.retrieve_estimated_delivery_date(
-  retrieved_shipment.id,
+  'shp_...',
   'YYYY-MM-DD',
 )
 

--- a/official/docs/ruby/current/smartrate/retrieve-time-in-transit-statistics.rb
+++ b/official/docs/ruby/current/smartrate/retrieve-time-in-transit-statistics.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_shipment = client.shipment.retrieve('shp_...')
-
-shipment = client.shipment.get_smart_rates(retrieved_shipment.id)
+shipment = client.shipment.get_smart_rates('shp_...')
 
 puts shipment

--- a/official/docs/ruby/current/webhooks/update.rb
+++ b/official/docs/ruby/current/webhooks/update.rb
@@ -2,8 +2,6 @@ require 'easypost'
 
 client = EasyPost::Client.new(api_key: 'EASYPOST_API_KEY')
 
-retrieved_webhook = client.webhook.retrieve('hook_...')
-
-webhook = client.webhook.update(retrieved_webhook.id)
+webhook = client.webhook.update('hook_...')
 
 puts webhook


### PR DESCRIPTION
This PR removes the unecessary retrieve calls from all examples. These were previously included because in non-thread-safe versions of our libs, methods were called on objects and not done statically meaning you needed to have an object locally to interact with, necessitating retrieving it first. This hasn't been the case for some time and instead we only require the ID of these objects. This drastically cleans up our examples and is more appropriate so we don't incorrectly add a bunch of API calls to integrations by showing them as "the way" to users.

Also fixes a couple of previously missed inconsistencies or syntax errors.
