### PR TITLE
Remove Webpack and Babel dependencies in ESLint

### DIFF
--- a/style_guides/node/.eslintrc
+++ b/style_guides/node/.eslintrc
@@ -1,11 +1,6 @@
 {
     "extends": ["prettier", "eslint:recommended"],
     "settings": {
-        "import/resolver": {
-            "webpack": {
-                "config": "webpack.config.babel.js"
-            }
-        },
         "import/extensions": ["", ".js", ".ejs", ".json", ".yml", ".jsx"],
         "import/ignore": [".ejs$", ".yml$", ".jsx", "node_modules"]
     },
@@ -17,14 +12,14 @@
         "lines-between-class-members": "off",
         "global-require": "off"
     },
-    "parser": "@babel/eslint-parser",
     "globals": {
         "window": true,
         "$": true
     },
     "parserOptions": {
         "ecmaVersion": 13,
-        "requireConfigFile": false
+        "requireConfigFile": false,
+        "sourceType": "module"
     },
     "env": {
         "node": true,

--- a/style_guides/node/.eslintrc
+++ b/style_guides/node/.eslintrc
@@ -1,28 +1,28 @@
 {
-    "extends": ["prettier", "eslint:recommended"],
-    "settings": {
-        "import/extensions": ["", ".js", ".ejs", ".json", ".yml", ".jsx"],
-        "import/ignore": [".ejs$", ".yml$", ".jsx", "node_modules"]
-    },
-    "rules": {
-        "no-console": "off",
-        "import/no-unresolved": "off",
-        "no-param-reassign": "off",
-        "filenames/match-regex": "off",
-        "lines-between-class-members": "off",
-        "global-require": "off"
-    },
-    "globals": {
-        "window": true,
-        "$": true
-    },
-    "parserOptions": {
-        "ecmaVersion": 13,
-        "requireConfigFile": false,
-        "sourceType": "module"
-    },
-    "env": {
-        "node": true,
-        "es6": true
-    }
+  "extends": ["prettier", "eslint:recommended"],
+  "settings": {
+    "import/extensions": ["", ".js", ".ejs", ".json", ".yml", ".jsx"],
+    "import/ignore": [".ejs$", ".yml$", ".jsx", "node_modules"]
+  },
+  "rules": {
+    "no-console": "off",
+    "import/no-unresolved": "off",
+    "no-param-reassign": "off",
+    "filenames/match-regex": "off",
+    "lines-between-class-members": "off",
+    "global-require": "off"
+  },
+  "globals": {
+    "window": true,
+    "$": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 13,
+    "requireConfigFile": false,
+    "sourceType": "module"
+  },
+  "env": {
+    "node": true,
+    "es6": true
+  }
 }

--- a/style_guides/node/.prettierignore
+++ b/style_guides/node/.prettierignore
@@ -1,9 +1,6 @@
-.babelrc
-.eslintrc
 .golangci.yml
 .mypy_cache
 .nyc_output
-README.md
 cassettes
 composer.json
 composer.lock
@@ -13,7 +10,6 @@ dist/
 examples
 official/fixtures/
 package-lock.json
-package.json
 style_guides/
 vendor/
 venv/


### PR DESCRIPTION
Unless I am missing something, these files are only used in the easypost/node client library, and they are safe to remove. I tested removing them, and the lint function still works.

Also removed the package.json, Readme, and other json-type files from prettierignore, since it would still be nice to be able to format those files when making changes.