### PR TITLE
[chore] Replace USPS service level name

### DIFF
--- a/official/fixtures/client-library-fixtures.json
+++ b/official/fixtures/client-library-fixtures.json
@@ -218,7 +218,7 @@
   },
   "service_names": {
     "usps": {
-      "first_service": "First",
+      "first_service": "GroundAdvantage",
       "pickup_service": "NextDay"
     }
   },


### PR DESCRIPTION
"First" is no more, need to use "GroundAdvantage" in unit tests