### PR TITLE
fix: use preferred method of error comparison for go guide example

### DIFF
--- a/official/guides/errors-guide/golang/catch-error.go
+++ b/official/guides/errors-guide/golang/catch-error.go
@@ -1,23 +1,26 @@
 package example
 
 import (
-    "fmt"
-    "github.com/EasyPost/easypost-go/v4"
+	"errors"
+	"fmt"
+
+	"github.com/EasyPost/easypost-go/v4"
 )
 
 func main() {
-    client := easypost.New("EASYPOST_API_KEY")
+	client := easypost.New("EASYPOST_API_KEY")
 
-    _, err := client.CreateAddress(
-        &easypost.Address{
-            // address params here
-        },
-        &easypost.CreateAddressOptions{
-            VerifyStrict: []string{"true"},
-        },
-    )
+	_, err := client.CreateAddress(
+		&easypost.Address{
+			// address params here
+		},
+		&easypost.CreateAddressOptions{
+			VerifyStrict: []string{"true"},
+		},
+	)
 
-    if err, ok := err.(*easypost.APIError); ok {
-        fmt.Println(err.Code)
-    }
+	var eperr *easypost.APIError
+	if errors.As(err, &eperr) {
+		fmt.Println(eperr.Code)
+	}
 }


### PR DESCRIPTION
Per the docs, this new method of error comparison is preferred, let's follow best practice: https://pkg.go.dev/errors (bottom)
