### PR TITLE
feat: custom header fixture

### DIFF
--- a/official/docs/curl/current/webhooks/create.sh
+++ b/official/docs/curl/current/webhooks/create.sh
@@ -3,6 +3,11 @@ curl -X POST https://api.easypost.com/v2/webhooks \
   -H 'Content-Type: application/json' \
   -d '{
     "webhook": {
-      "url": "example.com"
+      "url": "example.com",
+      "webhook_secret": "my_secret",
+      "custom_headers": [{
+        "name": "X-Header-Name",
+        "value": "header_value"
+      }],
     }
   }'

--- a/official/docs/curl/current/webhooks/update.sh
+++ b/official/docs/curl/current/webhooks/update.sh
@@ -1,2 +1,10 @@
 curl -X PATCH https://api.easypost.com/v2/webhooks/hook_... \
-  -u "EASYPOST_API_KEY":
+  -u "EASYPOST_API_KEY": \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "webhook_secret": "my_secret",
+    "custom_headers": [{
+      "name": "X-Header-Name",
+      "value": "header_value"
+    }],
+  }'

--- a/official/fixtures/client-library-fixtures.json
+++ b/official/fixtures/client-library-fixtures.json
@@ -321,7 +321,10 @@
       "phone": "5555555555"
     }
   },
-  "webhook_hmac_signature": "hmac-sha256-hex=38f3f53c103713df81616a0a186d77141957323ec21d5fe9363db93840f527db",
-  "webhook_secret": "sécret",
-  "webhook_url": "http://example.com"
+  "webhooks": {
+    "url": "http://example.com",
+    "secret": "sécret",
+    "custom_headers": [{"name": "test", "value": "header"}],
+    "hmac_signature": "hmac-sha256-hex=38f3f53c103713df81616a0a186d77141957323ec21d5fe9363db93840f527db"
+  }
 }


### PR DESCRIPTION
Adds a simple fixture for `custom_headers` and clarifies the curl snippets. Will do a follow-up PR for the other client libs once released.