### PR TITLE
fix: factory bot rule for rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    easypost (6.2.0)
+    easypost (6.4.1)
     json (2.10.1)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
@@ -19,7 +19,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     regexp_parser (2.10.0)
-    rubocop (1.72.0)
+    rubocop (1.73.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -30,12 +30,13 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.0)
+    rubocop-ast (1.38.1)
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.26.1)
-      rubocop (~> 1.61)
+    rubocop-factory_bot (2.27.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     rubocop-rspec (2.31.0)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
@@ -57,7 +58,7 @@ PLATFORMS
 
 DEPENDENCIES
   examples!
-  rubocop (= 1.72)
+  rubocop (= 1.73)
   rubocop-rspec (~> 2.31)
 
 BUNDLED WITH

--- a/examples.gemspec
+++ b/examples.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'easypost', '~> 6'
 
-  spec.add_development_dependency 'rubocop', '= 1.72'
+  spec.add_development_dependency 'rubocop', '= 1.73'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.31' # Can't upgrade to v3 until we drop Ruby 2.7
 end

--- a/style_guides/ruby/.rubocop.yml
+++ b/style_guides/ruby/.rubocop.yml
@@ -1,5 +1,12 @@
 inherit_from: easycop.yml
 
+AllCops:
+  SuggestExtensions: false
+  Exclude:
+    - docs/**/*
+    - examples/**/*
+    - vendor/**/*
+
 # We ignore frozen string literal comments to simplify the sample code snippets
 Style/FrozenStringLiteralComment:
   Enabled: false
@@ -12,13 +19,6 @@ Lint/UselessAssignment:
     - 'official/docs/ruby/**/api-keys/retrieve.rb'
 Naming/FileName:
   Enabled: false
-
-AllCops:
-  SuggestExtensions: false
-  Exclude:
-    - docs/**/*
-    - examples/**/*
-    - vendor/**/*
 # We are ignoring RSpec/FilePath because Simplecov doesn't play nice with nested spec files
 RSpec/FilePath:
   Enabled: false
@@ -26,3 +26,5 @@ RSpec/FilePath:
 Style/OptionalBooleanParameter:
   Exclude:
     - 'lib/easypost/services/*.rb'
+FactoryBot/CreateList:
+  Enabled: false

--- a/style_guides/ruby/easycop.yml
+++ b/style_guides/ruby/easycop.yml
@@ -176,5 +176,5 @@ Style/StringChars: # new in 1.12
   Enabled: true
 Style/SwapValues: # new in 1.1
   Enabled: true
-RSpec/Rails/AvoidSetupHook: # new in 2.4
+RSpecRails/AvoidSetupHook: # new in 2.4
   Enabled: true


### PR DESCRIPTION
Rubocop v1.73 introduced a new rule we don't want to incorporate - breaks the Ruby lib PRs without this exclusion.