### PR TITLE
feat: node v8 docs

### DIFF
--- a/official/docs/curl/current/webhooks/create.sh
+++ b/official/docs/curl/current/webhooks/create.sh
@@ -4,7 +4,7 @@ curl -X POST https://api.easypost.com/v2/webhooks \
   -d '{
     "webhook": {
       "url": "example.com",
-      "webhook_secret": "my_secret",
+      "webhook_secret": "A1B2C3",
       "custom_headers": [{
         "name": "X-Header-Name",
         "value": "header_value"

--- a/official/docs/curl/current/webhooks/update.sh
+++ b/official/docs/curl/current/webhooks/update.sh
@@ -2,7 +2,7 @@ curl -X PATCH https://api.easypost.com/v2/webhooks/hook_... \
   -u "EASYPOST_API_KEY": \
   -H 'Content-Type: application/json' \
   -d '{
-    "webhook_secret": "my_secret",
+    "webhook_secret": "A1B2C3",
     "custom_headers": [{
       "name": "X-Header-Name",
       "value": "header_value"

--- a/official/docs/node/current/billing/add-stripe-bank-account.js
+++ b/official/docs/node/current/billing/add-stripe-bank-account.js
@@ -1,0 +1,18 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const paymentMethod = await client.ReferralCustomer.addBankAccountFromStripe(
+    'REFERRAL_USER_API_KEY',
+    'fca_...',
+    {
+      ip_address: '127.0.0.1',
+      user_agent: 'Mozilla/5.0',
+      accepted_at: 172251073,
+    },
+    'primary',
+  );
+
+  console.log(paymentMethod);
+})();

--- a/official/docs/node/current/billing/add-stripe-credit-card.js
+++ b/official/docs/node/current/billing/add-stripe-credit-card.js
@@ -1,0 +1,13 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const paymentMethod = await client.ReferralCustomer.addCreditCardFromStripe(
+    'REFERRAL_USER_API_KEY',
+    'seti_123',
+    'primary',
+  );
+
+  console.log(paymentMethod);
+})();

--- a/official/docs/node/current/billing/create-stripe-bank-account-secret.js
+++ b/official/docs/node/current/billing/create-stripe-bank-account-secret.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const response = await client.BetaReferralCustomer.createBankAccountClientSecret();
+
+  console.log(response);
+})();

--- a/official/docs/node/current/billing/create-stripe-credit-card-secret.js
+++ b/official/docs/node/current/billing/create-stripe-credit-card-secret.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const response = await client.BetaReferralCustomer.createCreditCardClientSecret();
+
+  console.log(response);
+})();

--- a/official/docs/node/current/webhooks/update.js
+++ b/official/docs/node/current/webhooks/update.js
@@ -3,7 +3,12 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
-  const webhook = await client.Webhook.update('hook_...');
+  const webhook = await client.Webhook.update('hook_...', {
+    webhook_secret: 'A1B2C3',
+    customer_headers: {
+      'X-Header-Name': 'header_value',
+    },
+  });
 
   console.log(webhook);
 })();

--- a/official/docs/node/v7/addresses/create-and-verify.js
+++ b/official/docs/node/v7/addresses/create-and-verify.js
@@ -1,0 +1,17 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const address = await client.Address.createAndVerify({
+    street1: '000 unknown street',
+    city: 'Not A City',
+    state: 'ZZ',
+    zip: '00001',
+    country: 'US',
+    email: 'test@example.com',
+    phone: '5555555555',
+  });
+
+  console.log(address);
+})();

--- a/official/docs/node/v7/addresses/create.js
+++ b/official/docs/node/v7/addresses/create.js
@@ -1,0 +1,18 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const address = await client.Address.create({
+    street1: '417 MONTGOMERY ST',
+    street2: 'FLOOR 5',
+    city: 'SAN FRANCISCO',
+    state: 'CA',
+    zip: '94104',
+    country: 'US',
+    company: 'EasyPost',
+    phone: '415-123-4567',
+  });
+
+  console.log(address);
+})();

--- a/official/docs/node/v7/addresses/list.js
+++ b/official/docs/node/v7/addresses/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const addresses = await client.Address.all({
+    page_size: 5,
+  });
+
+  console.log(addresses);
+})();

--- a/official/docs/node/v7/addresses/retrieve.js
+++ b/official/docs/node/v7/addresses/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const address = await client.Address.retrieve('adr_...');
+
+  console.log(address);
+})();

--- a/official/docs/node/v7/addresses/verify-param.js
+++ b/official/docs/node/v7/addresses/verify-param.js
@@ -1,0 +1,18 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const address = await client.Address.create({
+    verify: true,
+    street1: '000 unknown street',
+    city: 'Not A City',
+    state: 'ZZ',
+    zip: '00001',
+    country: 'US',
+    email: 'test@example.com',
+    phone: '5555555555',
+  });
+
+  console.log(address);
+})();

--- a/official/docs/node/v7/addresses/verify-strict-param.js
+++ b/official/docs/node/v7/addresses/verify-strict-param.js
@@ -1,0 +1,18 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const address = await client.Address.create({
+    verify_strict: true,
+    street1: '000 unknown street',
+    city: 'Not A City',
+    state: 'ZZ',
+    zip: '00001',
+    country: 'US',
+    email: 'test@example.com',
+    phone: '5555555555',
+  });
+
+  console.log(address);
+})();

--- a/official/docs/node/v7/addresses/verify.js
+++ b/official/docs/node/v7/addresses/verify.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const address = await client.Address.verifyAddress('adr_...');
+
+  console.log(address);
+})();

--- a/official/docs/node/v7/api-keys/retrieve.js
+++ b/official/docs/node/v7/api-keys/retrieve.js
@@ -1,0 +1,15 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  // Retrieve all API keys including children
+  let apiKeys = await client.ApiKey.all();
+
+  console.log(apiKeys);
+
+  // Retrieve API keys for a specific child user
+  let childApiKeys = await client.ApiKey.retrieveApiKeysForUser('user_...');
+
+  console.log(childApiKeys);
+})();

--- a/official/docs/node/v7/batches/add-shipments.js
+++ b/official/docs/node/v7/batches/add-shipments.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const batch = await client.Batch.addShipments('batch_...', ['shp_...', 'shp_...']);
+
+  console.log(batch);
+})();

--- a/official/docs/node/v7/batches/buy.js
+++ b/official/docs/node/v7/batches/buy.js
@@ -1,0 +1,22 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const createdBatch = await client.Batch.create({
+    shipments: [
+      {
+        from_address: { id: 'adr_...' },
+        to_address: { id: 'adr_...' },
+        parcel: { id: 'prcl_...' },
+        service: 'First',
+        carrier: 'USPS',
+        carrier_accounts: ['ca_...'],
+      },
+    ],
+  });
+
+  const batch = await client.Batch.buy(createdBatch.id);
+
+  console.log(batch);
+})();

--- a/official/docs/node/v7/batches/create.js
+++ b/official/docs/node/v7/batches/create.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const batch = await client.Batch.create({
+    shipments: [{ id: 'shp_...' }, { id: 'shp_...' }],
+  });
+
+  console.log(batch);
+})();

--- a/official/docs/node/v7/batches/label.js
+++ b/official/docs/node/v7/batches/label.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const batch = await client.Batch.generateLabel('batch_...', 'PDF');
+
+  console.log(batch);
+})();

--- a/official/docs/node/v7/batches/list.js
+++ b/official/docs/node/v7/batches/list.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const batches = await client.Batch.all({ page_size: 5 });
+
+  console.log(batches);
+})();

--- a/official/docs/node/v7/batches/remove-shipments.js
+++ b/official/docs/node/v7/batches/remove-shipments.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const batch = await client.Batch.removeShipments('batch_...', ['shp_...']);
+
+  console.log(batch);
+})();

--- a/official/docs/node/v7/batches/retrieve.js
+++ b/official/docs/node/v7/batches/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const batch = await client.Batch.retrieve('batch_...');
+
+  console.log(batch);
+})();

--- a/official/docs/node/v7/batches/scan-forms.js
+++ b/official/docs/node/v7/batches/scan-forms.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const batch = await client.Batch.createScanForm('batch_...');
+
+  console.log(batch);
+})();

--- a/official/docs/node/v7/billing/create-ep-credit-card.js
+++ b/official/docs/node/v7/billing/create-ep-credit-card.js
@@ -1,0 +1,15 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const creditCard = await client.Referral.addCreditCard(
+    'REFERRAL_USER_API_KEY',
+    '0123456789101234',
+    '01',
+    '2025',
+    '111',
+  );
+
+  console.log(creditCard);
+})();

--- a/official/docs/node/v7/billing/delete.js
+++ b/official/docs/node/v7/billing/delete.js
@@ -1,0 +1,7 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  await client.Billing.deletePaymentMethod('primary');
+})();

--- a/official/docs/node/v7/billing/fund.js
+++ b/official/docs/node/v7/billing/fund.js
@@ -1,0 +1,7 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  await client.Billing.fundWallet('2000', 'primary');
+})();

--- a/official/docs/node/v7/billing/list.js
+++ b/official/docs/node/v7/billing/list.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const paymentMethods = await client.Billing.all();
+
+  console.log(paymentMethods);
+})();

--- a/official/docs/node/v7/brand/update.js
+++ b/official/docs/node/v7/brand/update.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const brand = await client.User.updateBrand('user_...', { color: '#303F9F' });
+
+  console.log(brand);
+})();

--- a/official/docs/node/v7/carrier-accounts/create.js
+++ b/official/docs/node/v7/carrier-accounts/create.js
@@ -1,0 +1,24 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const carrierAccount = await client.CarrierAccount.create({
+    type: 'DhlEcsAccount',
+    description: 'CA Location DHL eCommerce Solutions Account',
+    credentials: {
+      client_id: '123456',
+      client_secret: '123abc',
+      distribution_center: 'USLAX1',
+      pickup_id: '123456',
+    },
+    test_credentials: {
+      client_id: '123456',
+      client_secret: '123abc',
+      distribution_center: 'USLAX1',
+      pickup_id: '123456',
+    },
+  });
+
+  console.log(carrierAccount);
+})();

--- a/official/docs/node/v7/carrier-accounts/delete.js
+++ b/official/docs/node/v7/carrier-accounts/delete.js
@@ -1,0 +1,7 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  await client.CarrierAccount.delete('ca_...');
+})();

--- a/official/docs/node/v7/carrier-accounts/list.js
+++ b/official/docs/node/v7/carrier-accounts/list.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const carrierAccounts = await client.CarrierAccount.all();
+
+  console.log(carrierAccounts);
+})();

--- a/official/docs/node/v7/carrier-accounts/retrieve.js
+++ b/official/docs/node/v7/carrier-accounts/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const carrierAccount = await client.CarrierAccount.retrieve('ca_...');
+
+  console.log(carrierAccount);
+})();

--- a/official/docs/node/v7/carrier-accounts/update.js
+++ b/official/docs/node/v7/carrier-accounts/update.js
@@ -1,0 +1,12 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const CarrierAccount = await client.CarrierAccount.update('ca_...', {
+    description: 'FL Location DHL eCommerce Solutions Account',
+    credentials: { pickup_id: 'abc123' },
+  });
+
+  console.log(CarrierAccount);
+})();

--- a/official/docs/node/v7/carrier-metadata/retrieve.js
+++ b/official/docs/node/v7/carrier-metadata/retrieve.js
@@ -1,0 +1,16 @@
+const EasyPostBetaClient = require('@easypost/api');
+
+const client = new EasyPostBetaClient('EASYPOST_API_KEY');
+
+(async () => {
+  // Request all metadata for all carriers
+  const carrierMetadata = await client.CarrierMetadata.retrieve();
+  console.log(carrierMetadata);
+
+  // Request specific metadata for specific carriers
+  const carrierMetadataWithFilters = await client.CarrierMetadata.retrieve(
+    ['usps'],
+    ['service_levels', 'predefined_packages'],
+  );
+  console.log(carrierMetadataWithFilters);
+})();

--- a/official/docs/node/v7/carrier-types/list.js
+++ b/official/docs/node/v7/carrier-types/list.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const carrierTypes = await client.CarrierType.all();
+
+  console.log(carrierTypes);
+})();

--- a/official/docs/node/v7/child-users/create.js
+++ b/official/docs/node/v7/child-users/create.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const user = await client.User.create({
+    name: 'Child Account Name',
+  });
+
+  console.log(user);
+})();

--- a/official/docs/node/v7/child-users/delete.js
+++ b/official/docs/node/v7/child-users/delete.js
@@ -1,0 +1,7 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  await client.User.delete('user_...');
+})();

--- a/official/docs/node/v7/child-users/list.js
+++ b/official/docs/node/v7/child-users/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const childUsers = await client.User.allChildren({
+    page_size: 5,
+  });
+
+  console.log(childUsers);
+})();

--- a/official/docs/node/v7/claims/cancel.js
+++ b/official/docs/node/v7/claims/cancel.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const claim = await client.Claim.cancel('clm_...');
+
+  console.log(claim);
+})();

--- a/official/docs/node/v7/claims/create.js
+++ b/official/docs/node/v7/claims/create.js
@@ -1,0 +1,18 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const claim = await client.Claim.create({
+    type: 'damage',
+    email_evidence_attachments: ['REPLACE_WITH_BASE64_STRING'],
+    invoice_attachments: ['REPLACE_WITH_BASE64_STRING'],
+    supporting_documentation_attachments: ['REPLACE_WITH_BASE64_STRING'],
+    description: 'Test Description',
+    contact_email: 'test@example.com',
+    tracking_code: 'YOUR_TRACKING_CODE',
+    amount: '100',
+  });
+
+  console.log(claim);
+})();

--- a/official/docs/node/v7/claims/list.js
+++ b/official/docs/node/v7/claims/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const claims = await client.Claim.all({
+    page_size: 5,
+  });
+
+  console.log(claims);
+})();

--- a/official/docs/node/v7/claims/retrieve.js
+++ b/official/docs/node/v7/claims/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const claim = await client.Claim.retrieve('clm_...');
+
+  console.log(claim);
+})();

--- a/official/docs/node/v7/customs-infos/create.js
+++ b/official/docs/node/v7/customs-infos/create.js
@@ -1,0 +1,27 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const customsInfo = await client.CustomsInfo.create({
+    eel_pfc: 'NOEEI 30.37(a)',
+    customs_certify: true,
+    customs_signer: 'Steve Brule',
+    contents_type: 'merchandise',
+    contents_explanation: '',
+    restriction_type: 'none',
+    restriction_comments: '',
+    customs_items: [
+      {
+        description: 'T-shirts',
+        quantity: 1,
+        weight: 5,
+        value: 10,
+        hs_tariff_number: '123456',
+        origin_country: 'US',
+      },
+    ],
+  });
+
+  console.log(customsInfo);
+})();

--- a/official/docs/node/v7/customs-infos/retrieve.js
+++ b/official/docs/node/v7/customs-infos/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const customsInfo = await client.CustomsInfo.retrieve('cstinfo_...');
+
+  console.log(customsInfo);
+})();

--- a/official/docs/node/v7/customs-items/create.js
+++ b/official/docs/node/v7/customs-items/create.js
@@ -1,0 +1,16 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const customsItem = await client.CustomsItem.create({
+    description: 'T-shirt',
+    quantity: 1,
+    value: 10,
+    weight: 5,
+    hs_tariff_number: '123456',
+    origin_country: 'us',
+  });
+
+  console.log(customsItem);
+})();

--- a/official/docs/node/v7/customs-items/retrieve.js
+++ b/official/docs/node/v7/customs-items/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const customsItem = await client.CustomsItem.retrieve('cstitem_...');
+
+  console.log(customsItem);
+})();

--- a/official/docs/node/v7/endshipper/buy.js
+++ b/official/docs/node/v7/endshipper/buy.js
@@ -1,0 +1,17 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const retrievedShipment = await client.Shipment.retrieve('shp_...');
+
+  const shipment = await client.Shipment.buy(
+    retrievedShipment.id,
+    retrievedShipment.lowestRate(),
+    null,
+    false,
+    'es_...',
+  );
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/endshipper/create.js
+++ b/official/docs/node/v7/endshipper/create.js
@@ -1,0 +1,19 @@
+const EasyPostClient = require('@easypost/api');
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const endShipper = await client.EndShipper.create({
+    name: 'FOO BAR',
+    company: 'BAZ',
+    street1: '164 TOWNSEND STREET UNIT 1',
+    street2: 'UNIT 1',
+    city: 'SAN FRANCISCO',
+    state: 'CA',
+    zip: '94107',
+    country: 'US',
+    phone: '555-555-5555',
+    email: 'FOO@EXAMPLE.COM',
+  });
+
+  console.log(endShipper);
+})();

--- a/official/docs/node/v7/endshipper/list.js
+++ b/official/docs/node/v7/endshipper/list.js
@@ -1,0 +1,10 @@
+const EasyPostClient = require('@easypost/api');
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const endShippers = await client.EndShipper.all({
+    page_size: 5,
+  });
+
+  console.log(endShippers);
+})();

--- a/official/docs/node/v7/endshipper/retrieve.js
+++ b/official/docs/node/v7/endshipper/retrieve.js
@@ -1,0 +1,8 @@
+const EasyPostClient = require('@easypost/api');
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const endShipper = await client.EndShipper.retrieve('es_...');
+
+  console.log(endShipper);
+})();

--- a/official/docs/node/v7/endshipper/update.js
+++ b/official/docs/node/v7/endshipper/update.js
@@ -1,0 +1,19 @@
+const EasyPostClient = require('@easypost/api');
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const updatedEndShipper = await client.EndShipper.update('es_...', {
+    name: 'NEW NAME',
+    company: 'BAZ',
+    street1: '164 TOWNSEND STREET UNIT 1',
+    street2: 'UNIT 1',
+    city: 'SAN FRANCISCO',
+    state: 'CA',
+    zip: '94107',
+    country: 'US',
+    phone: '555-555-5555',
+    email: 'FOO@EXAMPLE.COM',
+  });
+
+  console.log(updatedEndShipper);
+})();

--- a/official/docs/node/v7/events/list.js
+++ b/official/docs/node/v7/events/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const events = await client.Event.all({
+    page_size: 5,
+  });
+
+  console.log(events);
+})();

--- a/official/docs/node/v7/events/retrieve.js
+++ b/official/docs/node/v7/events/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const event = await client.Event.retrieve('evt_...');
+
+  console.log(event);
+})();

--- a/official/docs/node/v7/forms/create.js
+++ b/official/docs/node/v7/forms/create.js
@@ -1,0 +1,20 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipmentWithForm = await client.Shipment.generateForm('shp_...', 'return_packing_slip', {
+    barcode: 'RMA12345678900',
+    line_items: [
+      {
+        product: {
+          title: 'Square Reader',
+          barcode: '855658003251',
+        },
+        units: '8',
+      },
+    ],
+  });
+
+  console.log(shipmentWithForm);
+})();

--- a/official/docs/node/v7/insurance/create.js
+++ b/official/docs/node/v7/insurance/create.js
@@ -1,0 +1,16 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const insurance = await client.Insurance.create({
+    to_address: { id: 'adr_...' },
+    from_address: { id: 'adr_...' },
+    tracking_code: '9400110898825022579493',
+    carrier: 'USPS',
+    amount: '100.00',
+    reference: 'insuranceRef1',
+  });
+
+  console.log(insurance);
+})();

--- a/official/docs/node/v7/insurance/list.js
+++ b/official/docs/node/v7/insurance/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const insurances = await client.Insurance.all({
+    page_size: 5,
+  });
+
+  console.log(insurances);
+})();

--- a/official/docs/node/v7/insurance/refund.js
+++ b/official/docs/node/v7/insurance/refund.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const insurance = await client.Insurance.refund('ins_...');
+
+  console.log(insurance);
+})();

--- a/official/docs/node/v7/insurance/retrieve.js
+++ b/official/docs/node/v7/insurance/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const insurance = await client.Insurance.retrieve('ins_...');
+
+  console.log(insurance);
+})();

--- a/official/docs/node/v7/options/create-with-options.js
+++ b/official/docs/node/v7/options/create-with-options.js
@@ -1,0 +1,16 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipment = await client.Shipment.create({
+    parcel: { id: 'prcl_...' },
+    to_address: { id: 'adr_...' },
+    from_address: { id: 'adr_...' },
+    options: {
+      print_custom_1: 'Custom label message',
+    },
+  });
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/orders/buy.js
+++ b/official/docs/node/v7/orders/buy.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const boughtOrder = await client.Order.buy('order_...', 'FedEx', 'FEDEX_GROUND');
+
+  console.log(boughtOrder);
+})();

--- a/official/docs/node/v7/orders/create.js
+++ b/official/docs/node/v7/orders/create.js
@@ -1,0 +1,25 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const order = await client.Order.create({
+    to_address: { id: 'adr_...' },
+    from_address: { id: 'adr_...' },
+    shipments: [
+      {
+        parcel: {
+          weight: 10.2,
+        },
+      },
+      {
+        parcel: {
+          predefined_package: 'FedExBox',
+          weight: 17.5,
+        },
+      },
+    ],
+  });
+
+  console.log(order);
+})();

--- a/official/docs/node/v7/orders/one-call-buy.js
+++ b/official/docs/node/v7/orders/one-call-buy.js
@@ -1,0 +1,27 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const order = await client.Order.create({
+    carrier_accounts: ['ca_...'],
+    service: 'NextDayAir',
+    to_address: 'adr_...',
+    from_address: 'adr_...',
+    shipments: [
+      {
+        parcel: {
+          weight: 10.2,
+        },
+      },
+      {
+        parcel: {
+          predefined_package: 'FedExBox',
+          weight: 17.5,
+        },
+      },
+    ],
+  });
+
+  console.log(order);
+})();

--- a/official/docs/node/v7/orders/retrieve.js
+++ b/official/docs/node/v7/orders/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const order = await client.Order.retrieve('order_...');
+
+  console.log(order);
+})();

--- a/official/docs/node/v7/pagination/get-next-page.js
+++ b/official/docs/node/v7/pagination/get-next-page.js
@@ -1,0 +1,15 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  // Get first page of results
+  const shipments = await client.Shipment.all({
+    page_size: 5,
+  });
+
+  // Provide the previous results page to move onto the next page
+  const nextPage = await client.Shipment.getNextPage(shipments);
+
+  console.log(nextPage);
+})();

--- a/official/docs/node/v7/parcels/create.js
+++ b/official/docs/node/v7/parcels/create.js
@@ -1,0 +1,14 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const parcel = await client.Parcel.create({
+    length: 20.2,
+    width: 10.9,
+    height: 5,
+    weight: 65.9,
+  });
+
+  console.log(parcel);
+})();

--- a/official/docs/node/v7/parcels/retrieve.js
+++ b/official/docs/node/v7/parcels/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const parcel = await client.Parcel.retrieve('prcl_...');
+
+  console.log(parcel);
+})();

--- a/official/docs/node/v7/payloads/list.js
+++ b/official/docs/node/v7/payloads/list.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const payloads = await client.Event.retrieveAllPayloads('evt_...');
+
+  console.log(payloads);
+})();

--- a/official/docs/node/v7/payloads/retrieve.js
+++ b/official/docs/node/v7/payloads/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const payload = await client.Event.retrievePayload('evt_...', 'payload_...');
+
+  console.log(payload);
+})();

--- a/official/docs/node/v7/pickups/buy.js
+++ b/official/docs/node/v7/pickups/buy.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const pickup = await client.Pickup.buy('pickup_...', 'UPS', 'Same-day Pickup');
+
+  console.log(pickup);
+})();

--- a/official/docs/node/v7/pickups/cancel.js
+++ b/official/docs/node/v7/pickups/cancel.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const cancelledPickup = await client.Pickup.cancel('pickup_...');
+
+  console.log(cancelledPickup);
+})();

--- a/official/docs/node/v7/pickups/create.js
+++ b/official/docs/node/v7/pickups/create.js
@@ -1,0 +1,17 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const pickup = await client.Pickup.create({
+    address: { id: 'adr_...' },
+    shipment: { id: 'shp_...' },
+    reference: 'my-first-pickup',
+    min_datetime: '2022-10-01 10:30:00',
+    max_datetime: '2022-10-02 10:30:00',
+    is_account_address: false,
+    instructions: 'Special pickup instructions',
+  });
+
+  console.log(pickup);
+})();

--- a/official/docs/node/v7/pickups/list.js
+++ b/official/docs/node/v7/pickups/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const pickups = await client.Pickup.all({
+    page_size: 5,
+  });
+
+  console.log(pickups);
+})();

--- a/official/docs/node/v7/pickups/retrieve.js
+++ b/official/docs/node/v7/pickups/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const pickup = await client.Pickup.retrieve('pickup_...');
+
+  console.log(pickup);
+})();

--- a/official/docs/node/v7/rates/regenerate.js
+++ b/official/docs/node/v7/rates/regenerate.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const rates = await client.Shipment.regenerateRates('shp_...');
+
+  console.log(rates);
+})();

--- a/official/docs/node/v7/rates/retrieve-stateless.js
+++ b/official/docs/node/v7/rates/retrieve-stateless.js
@@ -1,0 +1,38 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipmentDetails = {
+    to_address: {
+      name: 'Dr. Steve Brule',
+      street1: '179 N Harbor Dr',
+      city: 'Redondo Beach',
+      state: 'CA',
+      zip: '90277',
+      country: 'US',
+      email: 'dr_steve_brule@gmail.com',
+      phone: '4155559999',
+    },
+    from_address: {
+      street1: '417 montgomery street',
+      street2: 'FL 5',
+      city: 'San Francisco',
+      state: 'CA',
+      zip: '94104',
+      country: 'US',
+      company: 'EasyPost',
+      phone: '415-123-4567',
+    },
+    parcel: {
+      length: 20.2,
+      width: 10.9,
+      height: 5,
+      weight: 65.9,
+    },
+  };
+
+  const rates = await client.BetaRate.retrieveStatelessRates(shipmentDetails);
+
+  console.log(rates);
+})();

--- a/official/docs/node/v7/rates/retrieve.js
+++ b/official/docs/node/v7/rates/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const rate = await client.Rate.retrieve('rate...');
+
+  console.log(rate);
+})();

--- a/official/docs/node/v7/referral-customers/add-payment-method-with-bank-account.js
+++ b/official/docs/node/v7/referral-customers/add-payment-method-with-bank-account.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const paymentMethod = await client.BetaReferralCustomer.addPaymentMethod('cus_...', 'ba_...');
+
+  console.log(paymentMethod);
+})();

--- a/official/docs/node/v7/referral-customers/add-payment-method-with-credit-card.js
+++ b/official/docs/node/v7/referral-customers/add-payment-method-with-credit-card.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const paymentMethod = await client.BetaReferralCustomer.addPaymentMethod('cus_...', 'card_...');
+
+  console.log(paymentMethod);
+})();

--- a/official/docs/node/v7/referral-customers/create.js
+++ b/official/docs/node/v7/referral-customers/create.js
@@ -1,0 +1,13 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const referralCustomer = await client.ReferralCustomer.create({
+    name: 'Test Referral',
+    email: 'test@example.com',
+    phone: '1111111111',
+  });
+
+  console.log(referralCustomer);
+})();

--- a/official/docs/node/v7/referral-customers/list.js
+++ b/official/docs/node/v7/referral-customers/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const referralCustomers = await client.ReferralCustomer.all({
+    page_size: 5,
+  });
+
+  console.log(referralCustomers);
+})();

--- a/official/docs/node/v7/referral-customers/refund-by-amount.js
+++ b/official/docs/node/v7/referral-customers/refund-by-amount.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const refund = await client.BetaReferralCustomer.refundByAmount(2000);
+
+  console.log(refund);
+})();

--- a/official/docs/node/v7/referral-customers/refund-by-payment-log.js
+++ b/official/docs/node/v7/referral-customers/refund-by-payment-log.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const refund = await client.BetaReferralCustomer.refundByPaymentLog('paylog_...');
+
+  console.log(refund);
+})();

--- a/official/docs/node/v7/referral-customers/update.js
+++ b/official/docs/node/v7/referral-customers/update.js
@@ -1,0 +1,7 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  await client.ReferralCustomer.updateEmail('user_...', 'new_email@example.com');
+})();

--- a/official/docs/node/v7/refunds/create.js
+++ b/official/docs/node/v7/refunds/create.js
@@ -1,0 +1,12 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const refund = await client.Refund.create({
+    carrier: 'USPS',
+    tracking_codes: ['EZ1000000001'],
+  });
+
+  console.log(refund);
+})();

--- a/official/docs/node/v7/refunds/list.js
+++ b/official/docs/node/v7/refunds/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const refunds = await client.Refund.all({
+    page_size: 5,
+  });
+
+  console.log(refunds);
+})();

--- a/official/docs/node/v7/refunds/retrieve.js
+++ b/official/docs/node/v7/refunds/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const refund = await client.Refund.retrieve('rfnd_...');
+
+  console.log(refund);
+})();

--- a/official/docs/node/v7/reports/create.js
+++ b/official/docs/node/v7/reports/create.js
@@ -1,0 +1,13 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const report = await client.Report.create({
+    type: 'payment_log',
+    start_date: '2022-10-01',
+    end_date: '2022-10-31',
+  });
+
+  console.log(report);
+})();

--- a/official/docs/node/v7/reports/list.js
+++ b/official/docs/node/v7/reports/list.js
@@ -1,0 +1,10 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  // Replace `payment_log` with any of the report types listed above
+  const reports = await client.Report.all('payment_log', { page_size: 5 });
+
+  console.log(reports);
+})();

--- a/official/docs/node/v7/reports/retrieve.js
+++ b/official/docs/node/v7/reports/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const report = await client.Report.retrieve('<REPORT_ID>');
+
+  console.log(report);
+})();

--- a/official/docs/node/v7/returns/create.js
+++ b/official/docs/node/v7/returns/create.js
@@ -1,0 +1,14 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipment = await client.Shipment.create({
+    parcel: { id: 'prcl_...' },
+    to_address: { id: 'adr_...' },
+    from_address: { id: 'adr_...' },
+    is_return: true,
+  });
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/scan-form/create.js
+++ b/official/docs/node/v7/scan-form/create.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const scanForm = await client.ScanForm.create({
+    shipments: [{ id: 'shp_...' }, { id: 'shp_...' }],
+  });
+
+  console.log(scanForm);
+})();

--- a/official/docs/node/v7/scan-form/list.js
+++ b/official/docs/node/v7/scan-form/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const scanForms = await client.ScanForm.all({
+    page_size: 5,
+  });
+
+  console.log(scanForms);
+})();

--- a/official/docs/node/v7/scan-form/retrieve.js
+++ b/official/docs/node/v7/scan-form/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const scanForm = await client.ScanForm.retrieve('sf_...');
+
+  console.log(scanForm);
+})();

--- a/official/docs/node/v7/shipments/buy.js
+++ b/official/docs/node/v7/shipments/buy.js
@@ -1,0 +1,15 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const retrievedShipment = await client.Shipment.retrieve('shp_...');
+
+  const shipment = await client.Shipment.buy(
+    retrievedShipment.id,
+    retrievedShipment.lowestRate(),
+    249.99,
+  );
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/shipments/create.js
+++ b/official/docs/node/v7/shipments/create.js
@@ -1,0 +1,48 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  let shipment;
+
+  shipment = await client.Shipment.create({
+    to_address: {
+      name: 'Dr. Steve Brule',
+      street1: '179 N Harbor Dr',
+      city: 'Redondo Beach',
+      state: 'CA',
+      zip: '90277',
+      country: 'US',
+      email: 'dr_steve_brule@gmail.com',
+      phone: '4155559999',
+    },
+    from_address: {
+      street1: '417 montgomery street',
+      street2: 'FL 5',
+      city: 'San Francisco',
+      state: 'CA',
+      zip: '94104',
+      country: 'US',
+      company: 'EasyPost',
+      phone: '415-123-4567',
+    },
+    parcel: {
+      length: 20.2,
+      width: 10.9,
+      height: 5,
+      weight: 65.9,
+    },
+    customs_info: { id: 'cstinfo_...' },
+  });
+
+  // or create by using IDs
+
+  shipment = await client.Shipment.create({
+    to_address: { id: 'adr_...' },
+    from_address: { id: 'adr_...' },
+    parcel: { id: 'prcl_...' },
+    customs_info: { id: 'cstinfo_...' },
+  });
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/shipments/label.js
+++ b/official/docs/node/v7/shipments/label.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipment = await client.Shipment.convertLabelFormat('shp_...', 'ZPL');
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/shipments/list.js
+++ b/official/docs/node/v7/shipments/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipments = await client.Shipment.all({
+    page_size: 5,
+  });
+
+  console.log(shipments);
+})();

--- a/official/docs/node/v7/shipments/one-call-buy.js
+++ b/official/docs/node/v7/shipments/one-call-buy.js
@@ -1,0 +1,38 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipment = await client.Shipment.create({
+    carrier_accounts: ['ca_...'],
+    service: 'NextDayAir',
+    to_address: {
+      name: 'Dr. Steve Brule',
+      street1: '179 N Harbor Dr',
+      city: 'Redondo Beach',
+      state: 'CA',
+      zip: '90277',
+      country: 'US',
+      email: 'dr_steve_brule@gmail.com',
+      phone: '4155559999',
+    },
+    from_address: {
+      street1: '417 montgomery street',
+      street2: 'FL 5',
+      city: 'San Francisco',
+      state: 'CA',
+      zip: '94104',
+      country: 'US',
+      company: 'EasyPost',
+      phone: '415-123-4567',
+    },
+    parcel: {
+      length: 20.2,
+      width: 10.9,
+      height: 5,
+      weight: 65.9,
+    },
+  });
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/shipments/retrieve.js
+++ b/official/docs/node/v7/shipments/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipment = await client.Shipment.retrieve('shp_...');
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/shipping-insurance/insure.js
+++ b/official/docs/node/v7/shipping-insurance/insure.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipment = await client.Shipment.insure('shp_...', 100);
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/shipping-refund/refund.js
+++ b/official/docs/node/v7/shipping-refund/refund.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipment = await client.Shipment.refund('shp_...');
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/smartrate/retrieve-estimated-delivery-date.js
+++ b/official/docs/node/v7/smartrate/retrieve-estimated-delivery-date.js
@@ -1,0 +1,12 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const estimatedDeliveryDates = await client.Shipment.retrieveEstimatedDeliveryDate(
+    'shp_...',
+    'YYYY-MM-DD',
+  );
+
+  console.log(estimatedDeliveryDates);
+})();

--- a/official/docs/node/v7/smartrate/retrieve-recommend-ship-date.js
+++ b/official/docs/node/v7/smartrate/retrieve-recommend-ship-date.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const rates = await client.Shipment.recommendShipDate('shp_...', 'YYYY-MM-DD');
+
+  console.log(rates);
+})();

--- a/official/docs/node/v7/smartrate/retrieve-standalone-smartrate-deliver-by.js
+++ b/official/docs/node/v7/smartrate/retrieve-standalone-smartrate-deliver-by.js
@@ -1,0 +1,16 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+const params = {
+  from_zip: '10001',
+  to_zip: '10002',
+  planned_ship_date: '2024-07-18',
+  carriers: ['UPS'],
+};
+
+(async () => {
+  const results = await client.SmartRate.estimateDeliveryDate(params);
+
+  console.log(results);
+})();

--- a/official/docs/node/v7/smartrate/retrieve-standalone-smartrate-deliver-on.js
+++ b/official/docs/node/v7/smartrate/retrieve-standalone-smartrate-deliver-on.js
@@ -1,0 +1,16 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+const params = {
+  from_zip: '10001',
+  to_zip: '10002',
+  desired_delivery_date: '2024-07-18',
+  carriers: ['UPS'],
+};
+
+(async () => {
+  const results = await client.SmartRate.recommendShipDate(params);
+
+  console.log(results);
+})();

--- a/official/docs/node/v7/smartrate/retrieve-time-in-transit-statistics.js
+++ b/official/docs/node/v7/smartrate/retrieve-time-in-transit-statistics.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const smartRates = await client.Shipment.getSmartrates('shp_...');
+
+  console.log(smartRates);
+})();

--- a/official/docs/node/v7/tax-identifiers/create.js
+++ b/official/docs/node/v7/tax-identifiers/create.js
@@ -1,0 +1,47 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const shipment = await client.Shipment.create({
+    parcel: {
+      length: 20.2,
+      width: 10.9,
+      height: 5,
+      weight: 65.9,
+    },
+    to_address: {
+      name: 'Dr. Steve Brule',
+      street1: '179 N Harbor Dr',
+      city: 'Redondo Beach',
+      state: 'CA',
+      zip: '90277',
+      country: 'US',
+      email: 'dr_steve_brule@gmail.com',
+      phone: '4155559999',
+    },
+    from_address: {
+      street1: '417 montgomery street',
+      street2: 'FL 5',
+      city: 'San Francisco',
+      state: 'CA',
+      zip: '94104',
+      country: 'US',
+      company: 'EasyPost',
+      phone: '415-123-4567',
+    },
+    customs_info: {
+      id: 'cstinfo_...',
+    },
+    tax_identifiers: [
+      {
+        entity: 'SENDER',
+        tax_id: 'GB123456789',
+        tax_id_type: 'IOSS',
+        issuing_country: 'GB',
+      },
+    ],
+  });
+
+  console.log(shipment);
+})();

--- a/official/docs/node/v7/trackers/create.js
+++ b/official/docs/node/v7/trackers/create.js
@@ -1,0 +1,12 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const tracker = await client.Tracker.create({
+    tracking_code: 'EZ1000000001',
+    carrier: 'USPS',
+  });
+
+  console.log(tracker);
+})();

--- a/official/docs/node/v7/trackers/list.js
+++ b/official/docs/node/v7/trackers/list.js
@@ -1,0 +1,11 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const trackers = await client.Tracker.all({
+    page_size: 5,
+  });
+
+  console.log(trackers);
+})();

--- a/official/docs/node/v7/trackers/retrieve.js
+++ b/official/docs/node/v7/trackers/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const tracker = await client.Tracker.retrieve('trk_...');
+
+  console.log(tracker);
+})();

--- a/official/docs/node/v7/users/retrieve.js
+++ b/official/docs/node/v7/users/retrieve.js
@@ -1,0 +1,15 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  let user;
+
+  // Retrieve the authenticated user
+  user = await client.User.retrieveMe();
+
+  // Retrieve a child user
+  user = await client.User.retrieve('user_...');
+
+  console.log(user);
+})();

--- a/official/docs/node/v7/users/update.js
+++ b/official/docs/node/v7/users/update.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const user = await client.User.update('user_...', { recharge_threshold: '50.00' });
+
+  console.log(user);
+})();

--- a/official/docs/node/v7/webhooks/create.js
+++ b/official/docs/node/v7/webhooks/create.js
@@ -6,9 +6,6 @@ const client = new EasyPostClient('EASYPOST_API_KEY');
   const webhook = await client.Webhook.create({
     url: 'example.com',
     webhook_secret: 'A1B2C3',
-    customer_headers: {
-      'X-Header-Name': 'header_value',
-    },
   });
 
   console.log(webhook);

--- a/official/docs/node/v7/webhooks/delete.js
+++ b/official/docs/node/v7/webhooks/delete.js
@@ -1,0 +1,7 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  await client.Webhook.delete('hook_...');
+})();

--- a/official/docs/node/v7/webhooks/list.js
+++ b/official/docs/node/v7/webhooks/list.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const webhooks = await client.Webhook.all();
+
+  console.log(webhooks);
+})();

--- a/official/docs/node/v7/webhooks/retrieve.js
+++ b/official/docs/node/v7/webhooks/retrieve.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const webhook = await client.Webhook.retrieve('hook_...');
+
+  console.log(webhook);
+})();

--- a/official/docs/node/v7/webhooks/update.js
+++ b/official/docs/node/v7/webhooks/update.js
@@ -1,0 +1,9 @@
+const EasyPostClient = require('@easypost/api');
+
+const client = new EasyPostClient('EASYPOST_API_KEY');
+
+(async () => {
+  const webhook = await client.Webhook.update('hook_...');
+
+  console.log(webhook);
+})();

--- a/official/guides/errors-guide/node/catch-error.js
+++ b/official/guides/errors-guide/node/catch-error.js
@@ -3,9 +3,21 @@ const EasyPostClient = require('@easypost/api');
 const client = new EasyPostClient('EASYPOST_API_KEY');
 
 (async () => {
+  // When the `errors` key is returned as an array of FieldError objects
   try {
-    await client.Address.create({ strict_verify: true });
+    // Simulate a request with missing parameters
+    await client.Shipment.create({});
   } catch (error) {
-    console.error(error.code);
+    console.error(error.errors[0].message);
+  }
+
+  // When the `errors` key is returned as an array of strings
+  try {
+    const claimParameters = {
+      tracking_code: '123', // Simulate a request with an invalid tracking code
+    };
+    await client.Claim.create(claimParameters);
+  } catch (error) {
+    console.error(error.errors[0]);
   }
 })();


### PR DESCRIPTION
1. Copies `current` Node examples to `v7` (no changes)
2. Adds new billing examples
3. Adds missing custom_headers for webhooks
4. Overhauls error guide snippet to match new format