### PR TITLE
Replace extractions/setup-just with EasyPost/ep-actions setup/just action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - name: Run sh-checker
         uses: luizm/action-sh-checker@v0.9.0
         env:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - name: Install C# dependencies
         run: just install-csharp
       - name: Lint project
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: actions/setup-go@v5
         with:
           go-version: 1.23
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - name: Install Java dependencies
         run: just install-java
       - name: Lint project
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - name: Install dependencies
         run: just install-node
       - name: Lint project
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - name: Install dependencies
         run: just install-php
       - name: Lint project
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - name: Install Python dependencies
         run: just install-python
       - name: Lint project
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'


### PR DESCRIPTION
## What

Replaces the unverified third-party action `extractions/setup-just` with the internal composite action [`EasyPost/ep-actions/.github/actions/setup/just@main`](https://github.com/EasyPost/ep-actions/tree/main/.github/actions/setup/just).

## Why

`extractions/setup-just` is a third-party action from an unverified publisher and is **not** on the approved list in `EasyPost/ep-actions/ApprovedThirdPartyActions.yaml`. Using the internal composite action keeps CI on a vetted, EasyPost-owned action.

## Notes

- The ep-actions `setup/just` action installs Just on Linux runners; all affected jobs in this repo run on `ubuntu-latest`.
- The `just-version` input is supported by the ep-actions action where it was previously set.